### PR TITLE
feat: register products

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,12 +58,8 @@
 			<version>1.39.0</version>
 		</dependency>
 		<dependency>
-			<groupId>jakarta.validation</groupId>
-			<artifactId>jakarta.validation-api</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.hibernate.validator</groupId>
-			<artifactId>hibernate-validator</artifactId>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.cloudinary</groupId>
+			<artifactId>cloudinary-http44</artifactId>
+			<version>1.39.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,14 @@
 			<artifactId>cloudinary-http44</artifactId>
 			<version>1.39.0</version>
 		</dependency>
+		<dependency>
+			<groupId>jakarta.validation</groupId>
+			<artifactId>jakarta.validation-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate.validator</groupId>
+			<artifactId>hibernate-validator</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/_up/megastore/cloudinary/CloudinaryConfig.java
+++ b/src/main/java/com/_up/megastore/cloudinary/CloudinaryConfig.java
@@ -1,0 +1,33 @@
+package com._up.megastore.cloudinary;
+
+import com.cloudinary.Cloudinary;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Map;
+
+@Configuration
+public class CloudinaryConfig {
+
+    @Value("${cloudinary.cloud-name}")
+    private String CLOUD_NAME;
+
+    @Value("${cloudinary.api-key}")
+    private String API_KEY;
+
+    @Value("${cloudinary.api-secret}")
+    private String API_SECRET;
+
+    @Bean
+    public Cloudinary cloudinary() {
+        Map<String, String> cloudinaryProperties = Map.of(
+                "cloud_name", CLOUD_NAME,
+                "api_key", API_KEY,
+                "api_secret", API_SECRET
+        );
+
+        return new Cloudinary(cloudinaryProperties);
+    }
+
+}

--- a/src/main/java/com/_up/megastore/cloudinary/CloudinaryService.java
+++ b/src/main/java/com/_up/megastore/cloudinary/CloudinaryService.java
@@ -1,0 +1,30 @@
+package com._up.megastore.cloudinary;
+
+import com.cloudinary.Cloudinary;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Collections;
+
+@Service
+public class CloudinaryService {
+
+    private final Cloudinary cloudinary;
+
+    public CloudinaryService(Cloudinary cloudinary) {
+        this.cloudinary = cloudinary;
+    }
+
+    public String uploadImage(MultipartFile multipartFile) {
+        try {
+            return cloudinary.uploader()
+                    .upload(multipartFile.getBytes(), Collections.emptyMap())
+                    .get("url")
+                    .toString();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to upload image.", e);
+        }
+    }
+
+}

--- a/src/main/java/com/_up/megastore/cloudinary/CloudinaryService.java
+++ b/src/main/java/com/_up/megastore/cloudinary/CloudinaryService.java
@@ -1,5 +1,6 @@
 package com._up.megastore.cloudinary;
 
+import com._up.megastore.services.interfaces.IFileUploadService;
 import com.cloudinary.Cloudinary;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -8,7 +9,7 @@ import java.io.IOException;
 import java.util.Collections;
 
 @Service
-public class CloudinaryService {
+public class CloudinaryService implements IFileUploadService {
 
     private final Cloudinary cloudinary;
 

--- a/src/main/java/com/_up/megastore/controllers/implementations/CategoryController.java
+++ b/src/main/java/com/_up/megastore/controllers/implementations/CategoryController.java
@@ -1,0 +1,23 @@
+package com._up.megastore.controllers.implementations;
+
+import com._up.megastore.controllers.interfaces.ICategoryController;
+import com._up.megastore.controllers.requests.CreateCategoryRequest;
+import com._up.megastore.controllers.responses.CategoryResponse;
+import com._up.megastore.services.interfaces.ICategoryService;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class CategoryController implements ICategoryController {
+
+    private final ICategoryService categoryService;
+
+    public CategoryController(ICategoryService categoryService) {
+        this.categoryService = categoryService;
+    }
+
+    @Override
+    public CategoryResponse saveCategory(CreateCategoryRequest createCategoryRequest) {
+        return categoryService.saveCategory(createCategoryRequest);
+    }
+
+}

--- a/src/main/java/com/_up/megastore/controllers/implementations/ProductController.java
+++ b/src/main/java/com/_up/megastore/controllers/implementations/ProductController.java
@@ -1,0 +1,23 @@
+package com._up.megastore.controllers.implementations;
+
+import com._up.megastore.controllers.interfaces.IProductController;
+import com._up.megastore.controllers.requests.CreateProductRequest;
+import com._up.megastore.controllers.responses.ProductResponse;
+import com._up.megastore.services.interfaces.IProductService;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ProductController implements IProductController {
+
+    private final IProductService productService;
+
+    public ProductController(IProductService productService) {
+        this.productService = productService;
+    }
+
+    @Override
+    public ProductResponse saveProduct(CreateProductRequest createProductRequest) {
+        return productService.saveProduct(createProductRequest);
+    }
+
+}

--- a/src/main/java/com/_up/megastore/controllers/implementations/ProductController.java
+++ b/src/main/java/com/_up/megastore/controllers/implementations/ProductController.java
@@ -2,9 +2,11 @@ package com._up.megastore.controllers.implementations;
 
 import com._up.megastore.controllers.interfaces.IProductController;
 import com._up.megastore.controllers.requests.CreateProductRequest;
+import com._up.megastore.controllers.responses.ImageResponse;
 import com._up.megastore.controllers.responses.ProductResponse;
 import com._up.megastore.services.interfaces.IProductService;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 public class ProductController implements IProductController {
@@ -18,6 +20,11 @@ public class ProductController implements IProductController {
     @Override
     public ProductResponse saveProduct(CreateProductRequest createProductRequest) {
         return productService.saveProduct(createProductRequest);
+    }
+
+    @Override
+    public ImageResponse saveProductImage(MultipartFile multipartFile) {
+        return productService.saveProductImage(multipartFile);
     }
 
 }

--- a/src/main/java/com/_up/megastore/controllers/implementations/ProductController.java
+++ b/src/main/java/com/_up/megastore/controllers/implementations/ProductController.java
@@ -2,7 +2,6 @@ package com._up.megastore.controllers.implementations;
 
 import com._up.megastore.controllers.interfaces.IProductController;
 import com._up.megastore.controllers.requests.CreateProductRequest;
-import com._up.megastore.controllers.responses.ImageResponse;
 import com._up.megastore.controllers.responses.ProductResponse;
 import com._up.megastore.services.interfaces.IProductService;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,13 +17,8 @@ public class ProductController implements IProductController {
     }
 
     @Override
-    public ProductResponse saveProduct(CreateProductRequest createProductRequest) {
-        return productService.saveProduct(createProductRequest);
-    }
-
-    @Override
-    public ImageResponse saveProductImage(MultipartFile multipartFile) {
-        return productService.saveProductImage(multipartFile);
+    public ProductResponse saveProduct(CreateProductRequest createProductRequest, MultipartFile multipartFile) {
+        return productService.saveProduct(createProductRequest, multipartFile);
     }
 
 }

--- a/src/main/java/com/_up/megastore/controllers/implementations/SizeController.java
+++ b/src/main/java/com/_up/megastore/controllers/implementations/SizeController.java
@@ -1,0 +1,23 @@
+package com._up.megastore.controllers.implementations;
+
+import com._up.megastore.controllers.interfaces.ISizeController;
+import com._up.megastore.controllers.requests.CreateSizeRequest;
+import com._up.megastore.controllers.responses.SizeResponse;
+import com._up.megastore.services.interfaces.ISizeService;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class SizeController implements ISizeController {
+
+    private final ISizeService sizeService;
+
+    public SizeController(ISizeService sizeService) {
+        this.sizeService = sizeService;
+    }
+
+    @Override
+    public SizeResponse saveSize(CreateSizeRequest createSizeRequest) {
+        return sizeService.saveSize(createSizeRequest);
+    }
+
+}

--- a/src/main/java/com/_up/megastore/controllers/interfaces/ICategoryController.java
+++ b/src/main/java/com/_up/megastore/controllers/interfaces/ICategoryController.java
@@ -1,0 +1,18 @@
+package com._up.megastore.controllers.interfaces;
+
+import com._up.megastore.controllers.requests.CreateCategoryRequest;
+import com._up.megastore.controllers.responses.CategoryResponse;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@RequestMapping("/api/v1/categories")
+public interface ICategoryController {
+
+    @PostMapping @ResponseStatus(HttpStatus.CREATED)
+    CategoryResponse saveCategory(@RequestBody @Valid CreateCategoryRequest createCategoryRequest);
+
+}

--- a/src/main/java/com/_up/megastore/controllers/interfaces/IProductController.java
+++ b/src/main/java/com/_up/megastore/controllers/interfaces/IProductController.java
@@ -1,17 +1,20 @@
 package com._up.megastore.controllers.interfaces;
 
 import com._up.megastore.controllers.requests.CreateProductRequest;
+import com._up.megastore.controllers.responses.ImageResponse;
 import com._up.megastore.controllers.responses.ProductResponse;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RequestMapping("/api/v1/products")
 public interface IProductController {
 
     @PostMapping @ResponseStatus(HttpStatus.CREATED)
     ProductResponse saveProduct(@RequestBody CreateProductRequest createProductRequest);
+
+    @PostMapping(value = "/images", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE}) @ResponseStatus(HttpStatus.CREATED)
+    ImageResponse saveProductImage(@ModelAttribute MultipartFile multipartFile);
 
 }

--- a/src/main/java/com/_up/megastore/controllers/interfaces/IProductController.java
+++ b/src/main/java/com/_up/megastore/controllers/interfaces/IProductController.java
@@ -1,0 +1,17 @@
+package com._up.megastore.controllers.interfaces;
+
+import com._up.megastore.controllers.requests.CreateProductRequest;
+import com._up.megastore.controllers.responses.ProductResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@RequestMapping("/api/v1/products")
+public interface IProductController {
+
+    @PostMapping @ResponseStatus(HttpStatus.CREATED)
+    ProductResponse saveProduct(@RequestBody CreateProductRequest createProductRequest);
+
+}

--- a/src/main/java/com/_up/megastore/controllers/interfaces/IProductController.java
+++ b/src/main/java/com/_up/megastore/controllers/interfaces/IProductController.java
@@ -3,6 +3,7 @@ package com._up.megastore.controllers.interfaces;
 import com._up.megastore.controllers.requests.CreateProductRequest;
 import com._up.megastore.controllers.responses.ImageResponse;
 import com._up.megastore.controllers.responses.ProductResponse;
+import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
@@ -12,7 +13,7 @@ import org.springframework.web.multipart.MultipartFile;
 public interface IProductController {
 
     @PostMapping @ResponseStatus(HttpStatus.CREATED)
-    ProductResponse saveProduct(@RequestBody CreateProductRequest createProductRequest);
+    ProductResponse saveProduct(@RequestBody @Valid CreateProductRequest createProductRequest);
 
     @PostMapping(value = "/images", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE}) @ResponseStatus(HttpStatus.CREATED)
     ImageResponse saveProductImage(@ModelAttribute MultipartFile multipartFile);

--- a/src/main/java/com/_up/megastore/controllers/interfaces/IProductController.java
+++ b/src/main/java/com/_up/megastore/controllers/interfaces/IProductController.java
@@ -1,7 +1,6 @@
 package com._up.megastore.controllers.interfaces;
 
 import com._up.megastore.controllers.requests.CreateProductRequest;
-import com._up.megastore.controllers.responses.ImageResponse;
 import com._up.megastore.controllers.responses.ProductResponse;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
@@ -12,10 +11,11 @@ import org.springframework.web.multipart.MultipartFile;
 @RequestMapping("/api/v1/products")
 public interface IProductController {
 
-    @PostMapping @ResponseStatus(HttpStatus.CREATED)
-    ProductResponse saveProduct(@RequestBody @Valid CreateProductRequest createProductRequest);
-
-    @PostMapping(value = "/images", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE}) @ResponseStatus(HttpStatus.CREATED)
-    ImageResponse saveProductImage(@ModelAttribute MultipartFile multipartFile);
+    @PostMapping(consumes = { MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE })
+    @ResponseStatus(HttpStatus.CREATED)
+    ProductResponse saveProduct(
+            @RequestPart @Valid CreateProductRequest createProductRequest,
+            @RequestPart MultipartFile multipartFile
+    );
 
 }

--- a/src/main/java/com/_up/megastore/controllers/interfaces/ISizeController.java
+++ b/src/main/java/com/_up/megastore/controllers/interfaces/ISizeController.java
@@ -2,6 +2,7 @@ package com._up.megastore.controllers.interfaces;
 
 import com._up.megastore.controllers.requests.CreateSizeRequest;
 import com._up.megastore.controllers.responses.SizeResponse;
+import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -12,6 +13,6 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 public interface ISizeController {
 
     @PostMapping @ResponseStatus(HttpStatus.CREATED)
-    SizeResponse saveSize(@RequestBody CreateSizeRequest createSizeRequest);
+    SizeResponse saveSize(@RequestBody @Valid CreateSizeRequest createSizeRequest);
 
 }

--- a/src/main/java/com/_up/megastore/controllers/interfaces/ISizeController.java
+++ b/src/main/java/com/_up/megastore/controllers/interfaces/ISizeController.java
@@ -1,0 +1,17 @@
+package com._up.megastore.controllers.interfaces;
+
+import com._up.megastore.controllers.requests.CreateSizeRequest;
+import com._up.megastore.controllers.responses.SizeResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@RequestMapping("/api/v1/sizes")
+public interface ISizeController {
+
+    @PostMapping @ResponseStatus(HttpStatus.CREATED)
+    SizeResponse saveSize(@RequestBody CreateSizeRequest createSizeRequest);
+
+}

--- a/src/main/java/com/_up/megastore/controllers/requests/CreateCategoryRequest.java
+++ b/src/main/java/com/_up/megastore/controllers/requests/CreateCategoryRequest.java
@@ -1,17 +1,17 @@
 package com._up.megastore.controllers.requests;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 import java.util.UUID;
 
 public record CreateCategoryRequest(
 
-        @NotNull(message = "Category name must not be null")
+        @NotBlank(message = "Category name must not be blank")
         @Size(max = 20, message = "Category name must be less than 20 characters")
         String name,
 
-        @NotNull(message = "Category description must not be null")
+        @NotBlank(message = "Category description must not be blank")
         @Size(max = 50, message = "Category description must be less than 50 characters")
         String description,
 

--- a/src/main/java/com/_up/megastore/controllers/requests/CreateCategoryRequest.java
+++ b/src/main/java/com/_up/megastore/controllers/requests/CreateCategoryRequest.java
@@ -1,0 +1,19 @@
+package com._up.megastore.controllers.requests;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.UUID;
+
+public record CreateCategoryRequest(
+
+        @NotNull(message = "Category name must not be null")
+        @Size(max = 20, message = "Category name must be less than 30 characters")
+        String name,
+
+        @NotNull(message = "Category description must not be null")
+        @Size(max = 50, message = "Category description must be less than 30 characters")
+        String description,
+
+        UUID superCategoryId
+) {}

--- a/src/main/java/com/_up/megastore/controllers/requests/CreateCategoryRequest.java
+++ b/src/main/java/com/_up/megastore/controllers/requests/CreateCategoryRequest.java
@@ -8,11 +8,11 @@ import java.util.UUID;
 public record CreateCategoryRequest(
 
         @NotNull(message = "Category name must not be null")
-        @Size(max = 20, message = "Category name must be less than 30 characters")
+        @Size(max = 20, message = "Category name must be less than 20 characters")
         String name,
 
         @NotNull(message = "Category description must not be null")
-        @Size(max = 50, message = "Category description must be less than 30 characters")
+        @Size(max = 50, message = "Category description must be less than 50 characters")
         String description,
 
         UUID superCategoryId

--- a/src/main/java/com/_up/megastore/controllers/requests/CreateProductRequest.java
+++ b/src/main/java/com/_up/megastore/controllers/requests/CreateProductRequest.java
@@ -1,0 +1,16 @@
+package com._up.megastore.controllers.requests;
+
+import java.util.UUID;
+
+public record CreateProductRequest(
+
+        String name,
+        String description,
+        Double price,
+        String imageURL,
+        Integer stock,
+        String color,
+        UUID sizeId,
+        UUID variantOfId
+
+) {}

--- a/src/main/java/com/_up/megastore/controllers/requests/CreateProductRequest.java
+++ b/src/main/java/com/_up/megastore/controllers/requests/CreateProductRequest.java
@@ -18,7 +18,7 @@ public record CreateProductRequest(
         @Min(value = 0, message = "Price must be 0 or positive")
         Double price,
 
-        @NotBlank(message = "Product stock must not be null")
+        @NotNull(message = "Product stock must not be null")
         @Min(value = 0, message = "Product stock must be 0 or positive")
         Integer stock,
 

--- a/src/main/java/com/_up/megastore/controllers/requests/CreateProductRequest.java
+++ b/src/main/java/com/_up/megastore/controllers/requests/CreateProductRequest.java
@@ -1,29 +1,26 @@
 package com._up.megastore.controllers.requests;
 
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
 
 import java.util.UUID;
 
 public record CreateProductRequest(
 
-        @NotNull(message = "Product name must not be null")
+        @NotBlank(message = "Product name must not be null")
         @Size(max = 30, message = "Product name must be less than 30 characters")
         String name,
 
-        @NotNull(message = "Product description must not be null")
-        @Size(max = 80, message = "Product description must be less than 30 characters")
+        @NotBlank(message = "Product description must not be null")
+        @Size(max = 80, message = "Product description must be less than 80 characters")
         String description,
 
         @NotNull(message = "Product price must not be null")
         @Min(value = 0, message = "Price must be 0 or positive")
-        Double price,
+        double price,
 
         @NotNull(message = "Product stock must not be null")
         @Min(value = 0, message = "Product stock must be 0 or positive")
-        Integer stock,
+        int stock,
 
         @NotNull(message = "Product color must not be null")
         @Pattern(regexp = "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$", message = "Invalid color format")

--- a/src/main/java/com/_up/megastore/controllers/requests/CreateProductRequest.java
+++ b/src/main/java/com/_up/megastore/controllers/requests/CreateProductRequest.java
@@ -21,10 +21,6 @@ public record CreateProductRequest(
         @Min(value = 0, message = "Price must be 0 or positive")
         Double price,
 
-        @NotNull(message = "Image URL must not be null")
-        @Pattern(regexp = "^(https?|ftp)://[^ /$.?#].[^ ]*$", message = "Invalid image URL")
-        String imageURL,
-
         @NotNull(message = "Product stock must not be null")
         @Min(value = 0, message = "Product stock must be 0 or positive")
         Integer stock,

--- a/src/main/java/com/_up/megastore/controllers/requests/CreateProductRequest.java
+++ b/src/main/java/com/_up/megastore/controllers/requests/CreateProductRequest.java
@@ -6,19 +6,21 @@ import java.util.UUID;
 
 public record CreateProductRequest(
 
-        @NotBlank(message = "Product name must not be null")
+        @NotBlank(message = "Product name must not be blank")
         @Size(max = 30, message = "Product name must be less than 30 characters")
         String name,
 
-        @NotBlank(message = "Product description must not be null")
+        @NotBlank(message = "Product description must not be blank")
         @Size(max = 80, message = "Product description must be less than 80 characters")
         String description,
 
+        @NotNull(message = "Product price must not be null")
         @Min(value = 0, message = "Price must be 0 or positive")
-        double price,
+        Double price,
 
+        @NotBlank(message = "Product stock must not be null")
         @Min(value = 0, message = "Product stock must be 0 or positive")
-        int stock,
+        Integer stock,
 
         @NotNull(message = "Product color must not be null")
         @Pattern(regexp = "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$", message = "Invalid color format")

--- a/src/main/java/com/_up/megastore/controllers/requests/CreateProductRequest.java
+++ b/src/main/java/com/_up/megastore/controllers/requests/CreateProductRequest.java
@@ -32,5 +32,8 @@ public record CreateProductRequest(
         @NotNull(message = "Size ID must not be null")
         UUID sizeId,
 
+        @NotNull(message = "Category ID must not be null")
+        UUID categoryId,
+
         UUID variantOfId
 ) {}

--- a/src/main/java/com/_up/megastore/controllers/requests/CreateProductRequest.java
+++ b/src/main/java/com/_up/megastore/controllers/requests/CreateProductRequest.java
@@ -1,16 +1,40 @@
 package com._up.megastore.controllers.requests;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
 import java.util.UUID;
 
 public record CreateProductRequest(
 
+        @NotNull(message = "Product name must not be null")
+        @Size(max = 30, message = "Product name must be less than 30 characters")
         String name,
-        String description,
-        Double price,
-        String imageURL,
-        Integer stock,
-        String color,
-        UUID sizeId,
-        UUID variantOfId
 
+        @NotNull(message = "Product description must not be null")
+        @Size(max = 80, message = "Product description must be less than 30 characters")
+        String description,
+
+        @NotNull(message = "Product price must not be null")
+        @Min(value = 0, message = "Price must be 0 or positive")
+        Double price,
+
+        @NotNull(message = "Image URL must not be null")
+        @Pattern(regexp = "^(https?|ftp)://[^ /$.?#].[^ ]*$", message = "Invalid image URL")
+        String imageURL,
+
+        @NotNull(message = "Product stock must not be null")
+        @Min(value = 0, message = "Product stock must be 0 or positive")
+        Integer stock,
+
+        @NotNull(message = "Product color must not be null")
+        @Pattern(regexp = "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$", message = "Invalid color format")
+        String color,
+
+        @NotNull(message = "Size ID must not be null")
+        UUID sizeId,
+
+        UUID variantOfId
 ) {}

--- a/src/main/java/com/_up/megastore/controllers/requests/CreateProductRequest.java
+++ b/src/main/java/com/_up/megastore/controllers/requests/CreateProductRequest.java
@@ -14,11 +14,9 @@ public record CreateProductRequest(
         @Size(max = 80, message = "Product description must be less than 80 characters")
         String description,
 
-        @NotNull(message = "Product price must not be null")
         @Min(value = 0, message = "Price must be 0 or positive")
         double price,
 
-        @NotNull(message = "Product stock must not be null")
         @Min(value = 0, message = "Product stock must be 0 or positive")
         int stock,
 

--- a/src/main/java/com/_up/megastore/controllers/requests/CreateSizeRequest.java
+++ b/src/main/java/com/_up/megastore/controllers/requests/CreateSizeRequest.java
@@ -1,0 +1,6 @@
+package com._up.megastore.controllers.requests;
+
+public record CreateSizeRequest(
+        String name,
+        String description
+) {}

--- a/src/main/java/com/_up/megastore/controllers/requests/CreateSizeRequest.java
+++ b/src/main/java/com/_up/megastore/controllers/requests/CreateSizeRequest.java
@@ -6,10 +6,10 @@ import jakarta.validation.constraints.Size;
 public record CreateSizeRequest(
 
         @NotNull(message = "Size name must not be null")
-        @Size(max = 20, message = "Size name must be less than 30 characters")
+        @Size(max = 20, message = "Size name must be less than 20 characters")
         String name,
 
         @NotNull(message = "Size description must not be null")
-        @Size(max = 50, message = "Size description must be less than 30 characters")
+        @Size(max = 50, message = "Size description must be less than 50 characters")
         String description
 ) {}

--- a/src/main/java/com/_up/megastore/controllers/requests/CreateSizeRequest.java
+++ b/src/main/java/com/_up/megastore/controllers/requests/CreateSizeRequest.java
@@ -1,6 +1,15 @@
 package com._up.megastore.controllers.requests;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
 public record CreateSizeRequest(
+
+        @NotNull(message = "Size name must not be null")
+        @Size(max = 20, message = "Size name must be less than 30 characters")
         String name,
+
+        @NotNull(message = "Size description must not be null")
+        @Size(max = 50, message = "Size description must be less than 30 characters")
         String description
 ) {}

--- a/src/main/java/com/_up/megastore/controllers/responses/CategoryResponse.java
+++ b/src/main/java/com/_up/megastore/controllers/responses/CategoryResponse.java
@@ -1,0 +1,10 @@
+package com._up.megastore.controllers.responses;
+
+import java.util.UUID;
+
+public record CategoryResponse(
+        UUID categoryId,
+        String name,
+        String description,
+        String superCategoryName
+) {}

--- a/src/main/java/com/_up/megastore/controllers/responses/ImageResponse.java
+++ b/src/main/java/com/_up/megastore/controllers/responses/ImageResponse.java
@@ -1,5 +1,0 @@
-package com._up.megastore.controllers.responses;
-
-public record ImageResponse(
-        String imageURL
-) {}

--- a/src/main/java/com/_up/megastore/controllers/responses/ImageResponse.java
+++ b/src/main/java/com/_up/megastore/controllers/responses/ImageResponse.java
@@ -1,0 +1,5 @@
+package com._up.megastore.controllers.responses;
+
+public record ImageResponse(
+        String imageURL
+) {}

--- a/src/main/java/com/_up/megastore/controllers/responses/ProductResponse.java
+++ b/src/main/java/com/_up/megastore/controllers/responses/ProductResponse.java
@@ -3,15 +3,13 @@ package com._up.megastore.controllers.responses;
 import java.util.UUID;
 
 public record ProductResponse(
-
         UUID productId,
         String name,
         String description,
-        Double price,
+        double price,
         String imageURL,
-        Integer stock,
+        int stock,
         String color,
         String sizeName,
         String variantOfName
-
 ) {}

--- a/src/main/java/com/_up/megastore/controllers/responses/ProductResponse.java
+++ b/src/main/java/com/_up/megastore/controllers/responses/ProductResponse.java
@@ -1,0 +1,17 @@
+package com._up.megastore.controllers.responses;
+
+import java.util.UUID;
+
+public record ProductResponse(
+
+        UUID productId,
+        String name,
+        String description,
+        Double price,
+        String imageURL,
+        Integer stock,
+        String color,
+        String sizeName,
+        String variantOfName
+
+) {}

--- a/src/main/java/com/_up/megastore/controllers/responses/SizeResponse.java
+++ b/src/main/java/com/_up/megastore/controllers/responses/SizeResponse.java
@@ -1,0 +1,9 @@
+package com._up.megastore.controllers.responses;
+
+import java.util.UUID;
+
+public record SizeResponse(
+        UUID sizeId,
+        String name,
+        String description
+) {}

--- a/src/main/java/com/_up/megastore/data/model/Product.java
+++ b/src/main/java/com/_up/megastore/data/model/Product.java
@@ -35,6 +35,9 @@ public class Product {
     @ManyToOne @NonNull
     private Size size;
 
+    @ManyToOne @NonNull
+    private Category category;
+
     @ManyToOne
     private Product variantOf = null;
 

--- a/src/main/java/com/_up/megastore/exception/ExceptionControllerAdvice.java
+++ b/src/main/java/com/_up/megastore/exception/ExceptionControllerAdvice.java
@@ -12,15 +12,13 @@ import java.util.NoSuchElementException;
 @RestControllerAdvice
 public class ExceptionControllerAdvice {
 
-    private final LocalDateTime NOW = LocalDateTime.now();
-
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(NoSuchElementException.class)
     public ExceptionPayload handleNoSuchElementException(NoSuchElementException ex) {
         return new ExceptionPayload(
                 ex.getMessage(),
                 HttpStatus.BAD_REQUEST.value(),
-                NOW,
+                LocalDateTime.now(),
                 ex.getStackTrace()
         );
     }
@@ -29,9 +27,9 @@ public class ExceptionControllerAdvice {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ExceptionPayload handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
         return new ExceptionPayload(
-                ex.getBindingResult().getAllErrors().get(0).getDefaultMessage(),
+                ex.getBindingResult().getAllErrors().getFirst().getDefaultMessage(),
                 HttpStatus.BAD_REQUEST.value(),
-                NOW,
+                LocalDateTime.now(),
                 ex.getStackTrace()
         );
     }
@@ -42,7 +40,7 @@ public class ExceptionControllerAdvice {
         return new ExceptionPayload(
                 ex.getMessage(),
                 HttpStatus.SERVICE_UNAVAILABLE.value(),
-                NOW,
+                LocalDateTime.now(),
                 ex.getStackTrace()
         );
     }

--- a/src/main/java/com/_up/megastore/exception/ExceptionControllerAdvice.java
+++ b/src/main/java/com/_up/megastore/exception/ExceptionControllerAdvice.java
@@ -1,0 +1,50 @@
+package com._up.megastore.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.LocalDateTime;
+import java.util.NoSuchElementException;
+
+@RestControllerAdvice
+public class ExceptionControllerAdvice {
+
+    private final LocalDateTime NOW = LocalDateTime.now();
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(NoSuchElementException.class)
+    public ExceptionPayload handleNoSuchElementException(NoSuchElementException ex) {
+        return new ExceptionPayload(
+                ex.getMessage(),
+                HttpStatus.BAD_REQUEST.value(),
+                NOW,
+                ex.getStackTrace()
+        );
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ExceptionPayload handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
+        return new ExceptionPayload(
+                ex.getBindingResult().getAllErrors().get(0).getDefaultMessage(),
+                HttpStatus.BAD_REQUEST.value(),
+                NOW,
+                ex.getStackTrace()
+        );
+    }
+
+    @ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
+    @ExceptionHandler(RuntimeException.class)
+    public ExceptionPayload handleRuntimeException(RuntimeException ex) {
+        return new ExceptionPayload(
+                ex.getMessage(),
+                HttpStatus.SERVICE_UNAVAILABLE.value(),
+                NOW,
+                ex.getStackTrace()
+        );
+    }
+
+}

--- a/src/main/java/com/_up/megastore/exception/ExceptionPayload.java
+++ b/src/main/java/com/_up/megastore/exception/ExceptionPayload.java
@@ -1,0 +1,10 @@
+package com._up.megastore.exception;
+
+import java.time.LocalDateTime;
+
+public record ExceptionPayload(
+        String message,
+        Integer status,
+        LocalDateTime timestamp,
+        StackTraceElement[] stackTrace
+) {}

--- a/src/main/java/com/_up/megastore/services/implementations/CategoryService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/CategoryService.java
@@ -22,11 +22,8 @@ public class CategoryService implements ICategoryService {
 
     @Override
     public CategoryResponse saveCategory(CreateCategoryRequest createCategoryRequest) {
-        Category superCategory = createCategoryRequest.superCategoryId() != null
-                ? findCategoryByIdOrThrowException(createCategoryRequest.superCategoryId())
-                : null;
+        Category superCategory = getSuperCategory(createCategoryRequest.superCategoryId());
         Category category = CategoryMapper.toCategory(createCategoryRequest, superCategory);
-
         return CategoryMapper.toCategoryResponse( categoryRepository.save(category) );
     }
 
@@ -34,6 +31,10 @@ public class CategoryService implements ICategoryService {
     public Category findCategoryByIdOrThrowException(UUID categoryId) {
         return categoryRepository.findById(categoryId)
                 .orElseThrow(() -> new NoSuchElementException("Category with id " + categoryId + " does not exist."));
+    }
+
+    private Category getSuperCategory(UUID superCategoryId) {
+        return superCategoryId != null ? findCategoryByIdOrThrowException(superCategoryId) : null;
     }
 
 }

--- a/src/main/java/com/_up/megastore/services/implementations/CategoryService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/CategoryService.java
@@ -1,0 +1,39 @@
+package com._up.megastore.services.implementations;
+
+import com._up.megastore.controllers.requests.CreateCategoryRequest;
+import com._up.megastore.controllers.responses.CategoryResponse;
+import com._up.megastore.data.model.Category;
+import com._up.megastore.data.repositories.ICategoryRepository;
+import com._up.megastore.services.interfaces.ICategoryService;
+import com._up.megastore.services.mappers.CategoryMapper;
+import org.springframework.stereotype.Service;
+
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+@Service
+public class CategoryService implements ICategoryService {
+
+    private final ICategoryRepository categoryRepository;
+
+    public CategoryService(ICategoryRepository categoryRepository) {
+        this.categoryRepository = categoryRepository;
+    }
+
+    @Override
+    public CategoryResponse saveCategory(CreateCategoryRequest createCategoryRequest) {
+        Category superCategory = createCategoryRequest.superCategoryId() != null
+                ? findCategoryByIdOrThrowException(createCategoryRequest.superCategoryId())
+                : null;
+        Category category = CategoryMapper.toCategory(createCategoryRequest, superCategory);
+
+        return CategoryMapper.toCategoryResponse( categoryRepository.save(category) );
+    }
+
+    @Override
+    public Category findCategoryByIdOrThrowException(UUID categoryId) {
+        return categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new NoSuchElementException("Category with id " + categoryId + " does not exist."));
+    }
+
+}

--- a/src/main/java/com/_up/megastore/services/implementations/ProductService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/ProductService.java
@@ -1,6 +1,8 @@
 package com._up.megastore.services.implementations;
 
+import com._up.megastore.cloudinary.CloudinaryService;
 import com._up.megastore.controllers.requests.CreateProductRequest;
+import com._up.megastore.controllers.responses.ImageResponse;
 import com._up.megastore.controllers.responses.ProductResponse;
 import com._up.megastore.data.model.Product;
 import com._up.megastore.data.model.Size;
@@ -9,6 +11,7 @@ import com._up.megastore.services.interfaces.IProductService;
 import com._up.megastore.services.interfaces.ISizeService;
 import com._up.megastore.services.mappers.ProductMapper;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.NoSuchElementException;
 import java.util.UUID;
@@ -18,10 +21,12 @@ public class ProductService implements IProductService {
 
     private final IProductRepository productRepository;
     private final ISizeService sizeService;
+    private final CloudinaryService cloudinaryService;
 
-    public ProductService(IProductRepository productRepository, ISizeService sizeService) {
+    public ProductService(IProductRepository productRepository, ISizeService sizeService, CloudinaryService cloudinaryService) {
         this.productRepository = productRepository;
         this.sizeService = sizeService;
+        this.cloudinaryService = cloudinaryService;
     }
 
     @Override
@@ -39,6 +44,12 @@ public class ProductService implements IProductService {
     public Product findProductByIdOrThrowException(UUID productId) {
         return productRepository.findById(productId)
                 .orElseThrow(() -> new NoSuchElementException("Product with id " + productId + " does not exist."));
+    }
+
+    @Override
+    public ImageResponse saveProductImage(MultipartFile multipartFile) {
+        String imageURL = cloudinaryService.uploadImage(multipartFile);
+        return new ImageResponse(imageURL);
     }
 
 }

--- a/src/main/java/com/_up/megastore/services/implementations/ProductService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/ProductService.java
@@ -3,9 +3,11 @@ package com._up.megastore.services.implementations;
 import com._up.megastore.cloudinary.CloudinaryService;
 import com._up.megastore.controllers.requests.CreateProductRequest;
 import com._up.megastore.controllers.responses.ProductResponse;
+import com._up.megastore.data.model.Category;
 import com._up.megastore.data.model.Product;
 import com._up.megastore.data.model.Size;
 import com._up.megastore.data.repositories.IProductRepository;
+import com._up.megastore.services.interfaces.ICategoryService;
 import com._up.megastore.services.interfaces.IProductService;
 import com._up.megastore.services.interfaces.ISizeService;
 import com._up.megastore.services.mappers.ProductMapper;
@@ -20,23 +22,27 @@ public class ProductService implements IProductService {
 
     private final IProductRepository productRepository;
     private final ISizeService sizeService;
+    private final ICategoryService categoryService;
     private final CloudinaryService cloudinaryService;
 
-    public ProductService(IProductRepository productRepository, ISizeService sizeService, CloudinaryService cloudinaryService) {
+    public ProductService(IProductRepository productRepository, ISizeService sizeService, ICategoryService categoryService, CloudinaryService cloudinaryService) {
         this.productRepository = productRepository;
         this.sizeService = sizeService;
+        this.categoryService = categoryService;
         this.cloudinaryService = cloudinaryService;
     }
 
     @Override
     public ProductResponse saveProduct(CreateProductRequest createProductRequest, MultipartFile multipartFile) {
         Size size = sizeService.findSizeByIdOrThrowException(createProductRequest.sizeId());
+        Category category = categoryService.findCategoryByIdOrThrowException(createProductRequest.categoryId());
         Product variantOf = createProductRequest.variantOfId() != null
                 ? findProductByIdOrThrowException(createProductRequest.variantOfId())
                 : null;
+
         String imageURL = saveProductImage(multipartFile);
 
-        Product newProduct = ProductMapper.toProduct(createProductRequest, size, variantOf, imageURL);
+        Product newProduct = ProductMapper.toProduct(createProductRequest, size, category, variantOf, imageURL);
         return ProductMapper.toProductResponse( productRepository.save(newProduct) );
     }
 

--- a/src/main/java/com/_up/megastore/services/implementations/ProductService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/ProductService.java
@@ -1,0 +1,44 @@
+package com._up.megastore.services.implementations;
+
+import com._up.megastore.controllers.requests.CreateProductRequest;
+import com._up.megastore.controllers.responses.ProductResponse;
+import com._up.megastore.data.model.Product;
+import com._up.megastore.data.model.Size;
+import com._up.megastore.data.repositories.IProductRepository;
+import com._up.megastore.services.interfaces.IProductService;
+import com._up.megastore.services.interfaces.ISizeService;
+import com._up.megastore.services.mappers.ProductMapper;
+import org.springframework.stereotype.Service;
+
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+@Service
+public class ProductService implements IProductService {
+
+    private final IProductRepository productRepository;
+    private final ISizeService sizeService;
+
+    public ProductService(IProductRepository productRepository, ISizeService sizeService) {
+        this.productRepository = productRepository;
+        this.sizeService = sizeService;
+    }
+
+    @Override
+    public ProductResponse saveProduct(CreateProductRequest createProductRequest) {
+        Size size = sizeService.findSizeByIdOrThrowException(createProductRequest.sizeId());
+        Product variantOf = createProductRequest.variantOfId() != null
+                ? findProductByIdOrThrowException(createProductRequest.variantOfId())
+                : null;
+
+        Product newProduct = ProductMapper.toProduct(createProductRequest, size, variantOf);
+        return ProductMapper.toProductResponse( productRepository.save(newProduct) );
+    }
+
+    @Override
+    public Product findProductByIdOrThrowException(UUID productId) {
+        return productRepository.findById(productId)
+                .orElseThrow(() -> new NoSuchElementException("Product with id " + productId + " does not exist."));
+    }
+
+}

--- a/src/main/java/com/_up/megastore/services/implementations/ProductService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/ProductService.java
@@ -2,7 +2,6 @@ package com._up.megastore.services.implementations;
 
 import com._up.megastore.cloudinary.CloudinaryService;
 import com._up.megastore.controllers.requests.CreateProductRequest;
-import com._up.megastore.controllers.responses.ImageResponse;
 import com._up.megastore.controllers.responses.ProductResponse;
 import com._up.megastore.data.model.Product;
 import com._up.megastore.data.model.Size;
@@ -30,13 +29,14 @@ public class ProductService implements IProductService {
     }
 
     @Override
-    public ProductResponse saveProduct(CreateProductRequest createProductRequest) {
+    public ProductResponse saveProduct(CreateProductRequest createProductRequest, MultipartFile multipartFile) {
         Size size = sizeService.findSizeByIdOrThrowException(createProductRequest.sizeId());
         Product variantOf = createProductRequest.variantOfId() != null
                 ? findProductByIdOrThrowException(createProductRequest.variantOfId())
                 : null;
+        String imageURL = saveProductImage(multipartFile);
 
-        Product newProduct = ProductMapper.toProduct(createProductRequest, size, variantOf);
+        Product newProduct = ProductMapper.toProduct(createProductRequest, size, variantOf, imageURL);
         return ProductMapper.toProductResponse( productRepository.save(newProduct) );
     }
 
@@ -46,10 +46,8 @@ public class ProductService implements IProductService {
                 .orElseThrow(() -> new NoSuchElementException("Product with id " + productId + " does not exist."));
     }
 
-    @Override
-    public ImageResponse saveProductImage(MultipartFile multipartFile) {
-        String imageURL = cloudinaryService.uploadImage(multipartFile);
-        return new ImageResponse(imageURL);
+    private String saveProductImage(MultipartFile multipartFile) {
+        return cloudinaryService.uploadImage(multipartFile);
     }
 
 }

--- a/src/main/java/com/_up/megastore/services/implementations/SizeService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/SizeService.java
@@ -1,0 +1,27 @@
+package com._up.megastore.services.implementations;
+
+import com._up.megastore.controllers.requests.CreateSizeRequest;
+import com._up.megastore.controllers.responses.SizeResponse;
+import com._up.megastore.data.model.Size;
+import com._up.megastore.data.repositories.ISizeRepository;
+import com._up.megastore.services.interfaces.ISizeService;
+import com._up.megastore.services.mappers.SizeMapper;
+import org.springframework.stereotype.Service;
+
+@Service
+public class SizeService implements ISizeService {
+
+    private final ISizeRepository sizeRepository;
+
+    public SizeService(ISizeRepository sizeRepository) {
+        this.sizeRepository = sizeRepository;
+    }
+
+    @Override
+    public SizeResponse saveSize(CreateSizeRequest createSizeRequest) {
+        Size size = SizeMapper.toSize(createSizeRequest);
+        Size newSize = sizeRepository.save(size);
+        return SizeMapper.toSizeResponse(size);
+    }
+
+}

--- a/src/main/java/com/_up/megastore/services/implementations/SizeService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/SizeService.java
@@ -8,6 +8,9 @@ import com._up.megastore.services.interfaces.ISizeService;
 import com._up.megastore.services.mappers.SizeMapper;
 import org.springframework.stereotype.Service;
 
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
 @Service
 public class SizeService implements ISizeService {
 
@@ -20,8 +23,13 @@ public class SizeService implements ISizeService {
     @Override
     public SizeResponse saveSize(CreateSizeRequest createSizeRequest) {
         Size size = SizeMapper.toSize(createSizeRequest);
-        Size newSize = sizeRepository.save(size);
-        return SizeMapper.toSizeResponse(size);
+        return SizeMapper.toSizeResponse( sizeRepository.save(size) );
+    }
+
+    @Override
+    public Size findSizeByIdOrThrowException(UUID sizeId) {
+        return sizeRepository.findById(sizeId)
+                .orElseThrow( () -> new NoSuchElementException("Size with id " + sizeId + " does not exist.") );
     }
 
 }

--- a/src/main/java/com/_up/megastore/services/interfaces/ICategoryService.java
+++ b/src/main/java/com/_up/megastore/services/interfaces/ICategoryService.java
@@ -1,0 +1,15 @@
+package com._up.megastore.services.interfaces;
+
+import com._up.megastore.controllers.requests.CreateCategoryRequest;
+import com._up.megastore.controllers.responses.CategoryResponse;
+import com._up.megastore.data.model.Category;
+
+import java.util.UUID;
+
+public interface ICategoryService {
+
+    CategoryResponse saveCategory(CreateCategoryRequest createCategoryRequest);
+
+    Category findCategoryByIdOrThrowException(UUID categoryId);
+
+}

--- a/src/main/java/com/_up/megastore/services/interfaces/IFileUploadService.java
+++ b/src/main/java/com/_up/megastore/services/interfaces/IFileUploadService.java
@@ -1,0 +1,9 @@
+package com._up.megastore.services.interfaces;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface IFileUploadService {
+
+    String uploadImage(MultipartFile multipartFile);
+
+}

--- a/src/main/java/com/_up/megastore/services/interfaces/IProductService.java
+++ b/src/main/java/com/_up/megastore/services/interfaces/IProductService.java
@@ -1,0 +1,15 @@
+package com._up.megastore.services.interfaces;
+
+import com._up.megastore.controllers.requests.CreateProductRequest;
+import com._up.megastore.controllers.responses.ProductResponse;
+import com._up.megastore.data.model.Product;
+
+import java.util.UUID;
+
+public interface IProductService {
+
+    ProductResponse saveProduct(CreateProductRequest createProductRequest);
+
+    Product findProductByIdOrThrowException(UUID productId);
+
+}

--- a/src/main/java/com/_up/megastore/services/interfaces/IProductService.java
+++ b/src/main/java/com/_up/megastore/services/interfaces/IProductService.java
@@ -1,7 +1,6 @@
 package com._up.megastore.services.interfaces;
 
 import com._up.megastore.controllers.requests.CreateProductRequest;
-import com._up.megastore.controllers.responses.ImageResponse;
 import com._up.megastore.controllers.responses.ProductResponse;
 import com._up.megastore.data.model.Product;
 import org.springframework.web.multipart.MultipartFile;
@@ -10,10 +9,8 @@ import java.util.UUID;
 
 public interface IProductService {
 
-    ProductResponse saveProduct(CreateProductRequest createProductRequest);
+    ProductResponse saveProduct(CreateProductRequest createProductRequest, MultipartFile multipartFile);
 
     Product findProductByIdOrThrowException(UUID productId);
-
-    ImageResponse saveProductImage(MultipartFile multipartFile);
 
 }

--- a/src/main/java/com/_up/megastore/services/interfaces/IProductService.java
+++ b/src/main/java/com/_up/megastore/services/interfaces/IProductService.java
@@ -1,8 +1,10 @@
 package com._up.megastore.services.interfaces;
 
 import com._up.megastore.controllers.requests.CreateProductRequest;
+import com._up.megastore.controllers.responses.ImageResponse;
 import com._up.megastore.controllers.responses.ProductResponse;
 import com._up.megastore.data.model.Product;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.UUID;
 
@@ -11,5 +13,7 @@ public interface IProductService {
     ProductResponse saveProduct(CreateProductRequest createProductRequest);
 
     Product findProductByIdOrThrowException(UUID productId);
+
+    ImageResponse saveProductImage(MultipartFile multipartFile);
 
 }

--- a/src/main/java/com/_up/megastore/services/interfaces/ISizeService.java
+++ b/src/main/java/com/_up/megastore/services/interfaces/ISizeService.java
@@ -2,9 +2,14 @@ package com._up.megastore.services.interfaces;
 
 import com._up.megastore.controllers.requests.CreateSizeRequest;
 import com._up.megastore.controllers.responses.SizeResponse;
+import com._up.megastore.data.model.Size;
+
+import java.util.UUID;
 
 public interface ISizeService {
 
     SizeResponse saveSize(CreateSizeRequest createSizeRequest);
+
+    Size findSizeByIdOrThrowException(UUID sizeId);
 
 }

--- a/src/main/java/com/_up/megastore/services/interfaces/ISizeService.java
+++ b/src/main/java/com/_up/megastore/services/interfaces/ISizeService.java
@@ -1,0 +1,10 @@
+package com._up.megastore.services.interfaces;
+
+import com._up.megastore.controllers.requests.CreateSizeRequest;
+import com._up.megastore.controllers.responses.SizeResponse;
+
+public interface ISizeService {
+
+    SizeResponse saveSize(CreateSizeRequest createSizeRequest);
+
+}

--- a/src/main/java/com/_up/megastore/services/mappers/CategoryMapper.java
+++ b/src/main/java/com/_up/megastore/services/mappers/CategoryMapper.java
@@ -7,10 +7,7 @@ import com._up.megastore.data.model.Category;
 public class CategoryMapper {
 
     public static CategoryResponse toCategoryResponse(Category category) {
-        String superCategoryName = category.getSuperCategory() != null
-                ? category.getSuperCategory().getName()
-                : null;
-
+        String superCategoryName = getSuperCategoryName(category.getSuperCategory());
         return new CategoryResponse(category.getCategoryId(), category.getName(), category.getDescription(), superCategoryName);
     }
 
@@ -20,6 +17,10 @@ public class CategoryMapper {
                 .description(createCategoryRequest.description())
                 .superCategory(superCategory)
                 .build();
+    }
+
+    private static String getSuperCategoryName(Category superCategory) {
+        return superCategory != null ? superCategory.getName() : null;
     }
 
 }

--- a/src/main/java/com/_up/megastore/services/mappers/CategoryMapper.java
+++ b/src/main/java/com/_up/megastore/services/mappers/CategoryMapper.java
@@ -1,0 +1,25 @@
+package com._up.megastore.services.mappers;
+
+import com._up.megastore.controllers.requests.CreateCategoryRequest;
+import com._up.megastore.controllers.responses.CategoryResponse;
+import com._up.megastore.data.model.Category;
+
+public class CategoryMapper {
+
+    public static CategoryResponse toCategoryResponse(Category category) {
+        String superCategoryName = category.getSuperCategory() != null
+                ? category.getSuperCategory().getName()
+                : null;
+
+        return new CategoryResponse(category.getCategoryId(), category.getName(), category.getDescription(), superCategoryName);
+    }
+
+    public static Category toCategory(CreateCategoryRequest createCategoryRequest, Category superCategory) {
+        return Category.builder()
+                .name(createCategoryRequest.name())
+                .description(createCategoryRequest.description())
+                .superCategory(superCategory)
+                .build();
+    }
+
+}

--- a/src/main/java/com/_up/megastore/services/mappers/ProductMapper.java
+++ b/src/main/java/com/_up/megastore/services/mappers/ProductMapper.java
@@ -2,6 +2,7 @@ package com._up.megastore.services.mappers;
 
 import com._up.megastore.controllers.requests.CreateProductRequest;
 import com._up.megastore.controllers.responses.ProductResponse;
+import com._up.megastore.data.model.Category;
 import com._up.megastore.data.model.Product;
 import com._up.megastore.data.model.Size;
 
@@ -25,7 +26,7 @@ public class ProductMapper {
         );
     }
 
-    public static Product toProduct(CreateProductRequest createProductRequest, Size size, Product variantOf, String imageURL) {
+    public static Product toProduct(CreateProductRequest createProductRequest, Size size, Category category, Product variantOf, String imageURL) {
         return Product.builder()
                 .name(createProductRequest.name())
                 .description(createProductRequest.description())
@@ -34,6 +35,7 @@ public class ProductMapper {
                 .stock(createProductRequest.stock())
                 .color(createProductRequest.color())
                 .size(size)
+                .category(category)
                 .variantOf(variantOf)
                 .build();
     }

--- a/src/main/java/com/_up/megastore/services/mappers/ProductMapper.java
+++ b/src/main/java/com/_up/megastore/services/mappers/ProductMapper.java
@@ -25,12 +25,12 @@ public class ProductMapper {
         );
     }
 
-    public static Product toProduct(CreateProductRequest createProductRequest, Size size, Product variantOf) {
+    public static Product toProduct(CreateProductRequest createProductRequest, Size size, Product variantOf, String imageURL) {
         return Product.builder()
                 .name(createProductRequest.name())
                 .description(createProductRequest.description())
                 .price(createProductRequest.price())
-                .imageURL(createProductRequest.imageURL())
+                .imageURL(imageURL)
                 .stock(createProductRequest.stock())
                 .color(createProductRequest.color())
                 .size(size)

--- a/src/main/java/com/_up/megastore/services/mappers/ProductMapper.java
+++ b/src/main/java/com/_up/megastore/services/mappers/ProductMapper.java
@@ -9,9 +9,7 @@ import com._up.megastore.data.model.Size;
 public class ProductMapper {
 
     public static ProductResponse toProductResponse(Product product) {
-        String variantName = product.getVariantOf() != null
-                ? product.getVariantOf().getName()
-                : null;
+        String variantName = getVariantName(product.getVariantOf());
 
         return new ProductResponse(
                 product.getProductId(),
@@ -38,6 +36,10 @@ public class ProductMapper {
                 .category(category)
                 .variantOf(variantOf)
                 .build();
+    }
+
+    private static String getVariantName(Product variant) {
+        return variant != null ? variant.getName() : null;
     }
 
 }

--- a/src/main/java/com/_up/megastore/services/mappers/ProductMapper.java
+++ b/src/main/java/com/_up/megastore/services/mappers/ProductMapper.java
@@ -1,0 +1,41 @@
+package com._up.megastore.services.mappers;
+
+import com._up.megastore.controllers.requests.CreateProductRequest;
+import com._up.megastore.controllers.responses.ProductResponse;
+import com._up.megastore.data.model.Product;
+import com._up.megastore.data.model.Size;
+
+public class ProductMapper {
+
+    public static ProductResponse toProductResponse(Product product) {
+        String variantName = product.getVariantOf() != null
+                ? product.getVariantOf().getName()
+                : null;
+
+        return new ProductResponse(
+                product.getProductId(),
+                product.getName(),
+                product.getDescription(),
+                product.getPrice(),
+                product.getImageURL(),
+                product.getStock(),
+                product.getColor(),
+                product.getSize().getName(),
+                variantName
+        );
+    }
+
+    public static Product toProduct(CreateProductRequest createProductRequest, Size size, Product variantOf) {
+        return Product.builder()
+                .name(createProductRequest.name())
+                .description(createProductRequest.description())
+                .price(createProductRequest.price())
+                .imageURL(createProductRequest.imageURL())
+                .stock(createProductRequest.stock())
+                .color(createProductRequest.color())
+                .size(size)
+                .variantOf(variantOf)
+                .build();
+    }
+
+}

--- a/src/main/java/com/_up/megastore/services/mappers/SizeMapper.java
+++ b/src/main/java/com/_up/megastore/services/mappers/SizeMapper.java
@@ -1,0 +1,20 @@
+package com._up.megastore.services.mappers;
+
+import com._up.megastore.controllers.requests.CreateSizeRequest;
+import com._up.megastore.controllers.responses.SizeResponse;
+import com._up.megastore.data.model.Size;
+
+public class SizeMapper {
+
+    public static SizeResponse toSizeResponse(Size size) {
+        return new SizeResponse(size.getSizeId(), size.getName(), size.getDescription());
+    }
+
+    public static Size toSize(CreateSizeRequest createSizeRequest) {
+        return Size.builder()
+                .name(createSizeRequest.name())
+                .description(createSizeRequest.description())
+                .build();
+    }
+
+}

--- a/src/main/resources/application-development.yaml
+++ b/src/main/resources/application-development.yaml
@@ -1,0 +1,4 @@
+cloudinary:
+  cloud-name: ${CLOUDINARY_NAME:dlomx8sc1}
+  api-key: ${CLOUDINARY_API_KEY:363723365928819}
+  api-secret: ${CLOUDINARY_API_SECRET:z1aLT2IRKpN97R8vMYNZAvFYG68}

--- a/src/main/resources/application-development.yaml
+++ b/src/main/resources/application-development.yaml
@@ -1,4 +1,4 @@
 cloudinary:
-  cloud-name: ${CLOUDINARY_NAME:dlomx8sc1}
-  api-key: ${CLOUDINARY_API_KEY:363723365928819}
-  api-secret: ${CLOUDINARY_API_SECRET:z1aLT2IRKpN97R8vMYNZAvFYG68}
+  cloud-name: dlomx8sc1
+  api-key: 363723365928819
+  api-secret: z1aLT2IRKpN97R8vMYNZAvFYG68

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,8 +10,5 @@ spring:
     username: ${DB_USERNAME:root}
     password: ${DB_PASSWORD:password}
     driver-class-name: com.mysql.cj.jdbc.Driver
-
-cloudinary:
-  cloud-name: ${CLOUDINARY_NAME:dlomx8sc1}
-  api-key: ${CLOUDINARY_API_KEY:363723365928819}
-  api-secret: ${CLOUDINARY_API_SECRET:z1aLT2IRKpN97R8vMYNZAvFYG68}
+  profiles:
+    active: ${SPRING_PROFILE:development}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,3 +10,8 @@ spring:
     username: ${DB_USERNAME:root}
     password: ${DB_PASSWORD:password}
     driver-class-name: com.mysql.cj.jdbc.Driver
+
+cloudinary:
+  cloud-name: ${CLOUDINARY_NAME:dlomx8sc1}
+  api-key: ${CLOUDINARY_API_KEY:363723365928819}
+  api-secret: ${CLOUDINARY_API_SECRET:z1aLT2IRKpN97R8vMYNZAvFYG68}


### PR DESCRIPTION
Se agregó la funcionalidad completa de registrar productos, tamaños y categorías de productos. La relación producto -> categoría no estaba por lo que también fue añadida en el model. Las cuestiones agregadas fueron:

- DTOs con sus correspondientes validaciones
- Mappers para transformar DTOs a entities y viceversa
- Controllers y services de los productos, tamaños y categorías para exponer los endpoints y procesar las solicitudes, respectivamente
- Integración con [Cloudinary](https://cloudinary.com/) para guardar las imágenes de los productos
- Manejo de excepciones como resultado de las validaciones y de la subida de imágenes a la nube