### PR TITLE
feat: restore products

### DIFF
--- a/src/main/java/com/_up/megastore/controllers/implementations/ProductController.java
+++ b/src/main/java/com/_up/megastore/controllers/implementations/ProductController.java
@@ -28,5 +28,9 @@ public class ProductController implements IProductController {
 
     }
 
+    @Override
+    public ProductResponse restoreProduct(UUID productId) {
+        return productService.restoreProduct(productId);
+    }
 
 }

--- a/src/main/java/com/_up/megastore/controllers/interfaces/IProductController.java
+++ b/src/main/java/com/_up/megastore/controllers/interfaces/IProductController.java
@@ -30,7 +30,7 @@ public interface IProductController {
             @RequestPart @Nullable MultipartFile multipartFile
     );
 
-    @PatchMapping("/{productId}/restore")
+    @PostMapping("/{productId}/restore")
     @ResponseStatus(HttpStatus.OK)
     ProductResponse restoreProduct(@PathVariable UUID productId);
 

--- a/src/main/java/com/_up/megastore/controllers/interfaces/IProductController.java
+++ b/src/main/java/com/_up/megastore/controllers/interfaces/IProductController.java
@@ -30,4 +30,8 @@ public interface IProductController {
             @RequestPart @Nullable MultipartFile multipartFile
     );
 
+    @PatchMapping("/{productId}/restore")
+    @ResponseStatus(HttpStatus.OK)
+    ProductResponse restoreProduct(@PathVariable UUID productId);
+
 }

--- a/src/main/java/com/_up/megastore/data/repositories/IProductRepository.java
+++ b/src/main/java/com/_up/megastore/data/repositories/IProductRepository.java
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.UUID;
 
 public interface IProductRepository extends JpaRepository<Product, UUID> {
+    boolean existsByProductIdAndDeletedTrue(UUID productId);
 }

--- a/src/main/java/com/_up/megastore/exception/ExceptionControllerAdvice.java
+++ b/src/main/java/com/_up/megastore/exception/ExceptionControllerAdvice.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestControllerAdvice
 public class ExceptionControllerAdvice {
@@ -55,5 +56,16 @@ public class ExceptionControllerAdvice {
         ex.getStackTrace()
     );
   }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(ResponseStatusException.class)
+    public ExceptionPayload handleResponseStatusException(ResponseStatusException ex) {
+        return new ExceptionPayload(
+                ex.getReason(),
+                ex.getStatusCode().value(),
+                LocalDateTime.now(),
+                ex.getStackTrace()
+        );
+    }
 
 }

--- a/src/main/java/com/_up/megastore/services/implementations/ProductService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/ProductService.java
@@ -97,7 +97,7 @@ public class ProductService implements IProductService {
     }
 
     private void validateProductForRestoration(UUID productId) {
-        Product product = productRepository.findById(productId).orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Product with id " + productId + " does not exist."));
+        Product product = findProductByIdOrThrowException(productId);
         if (!product.isDeleted()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Product with id " + productId + " is not deleted.");
         }

--- a/src/main/java/com/_up/megastore/services/implementations/ProductService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/ProductService.java
@@ -97,18 +97,8 @@ public class ProductService implements IProductService {
     }
 
     private void validateProductForRestoration(UUID productId) {
-        ifProductDoesNotExistThrowException(productId);
-        ifProductIsNotDeletedThrowException(productId);
-    }
-
-    private void ifProductDoesNotExistThrowException(UUID productId) {
-        if (!productRepository.existsById(productId)) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Product with id " + productId + " does not exist.");
-        }
-    }
-
-    private void ifProductIsNotDeletedThrowException(UUID productId) {
-        if (!productRepository.existsByProductIdAndDeletedTrue(productId)) {
+        Product product = productRepository.findById(productId).orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Product with id " + productId + " does not exist."));
+        if (!product.isDeleted()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Product with id " + productId + " is not deleted.");
         }
     }

--- a/src/main/java/com/_up/megastore/services/interfaces/IProductService.java
+++ b/src/main/java/com/_up/megastore/services/interfaces/IProductService.java
@@ -16,4 +16,6 @@ public interface IProductService {
 
     ProductResponse updateProduct(UUID productId, UpdateProductRequest updateProductRequest, MultipartFile multipartFile);
 
+    ProductResponse restoreProduct(UUID productId);
+
 }


### PR DESCRIPTION
Se agregó el endpoint para restaurar los productos que fueron previamente eliminados. Se utilizó un Patch puesto que se actualiza únicamente la flag 'deleted' a false de la entidad. En cuanto a la validación, se utilizaron Query Methods para manejar todas las posibilidades