### PR TITLE
feat: send confirmation email

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,10 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-mail</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/_up/megastore/MegastoreApplication.java
+++ b/src/main/java/com/_up/megastore/MegastoreApplication.java
@@ -2,8 +2,10 @@ package com._up.megastore;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
+@EnableAsync
 public class MegastoreApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(MegastoreApplication.class, args);

--- a/src/main/java/com/_up/megastore/MegastoreApplication.java
+++ b/src/main/java/com/_up/megastore/MegastoreApplication.java
@@ -2,10 +2,8 @@ package com._up.megastore;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
-@EnableAsync
 public class MegastoreApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(MegastoreApplication.class, args);

--- a/src/main/java/com/_up/megastore/config/CorsConfig.java
+++ b/src/main/java/com/_up/megastore/config/CorsConfig.java
@@ -1,0 +1,27 @@
+package com._up.megastore.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig {
+  @Value("${app.cors.allowed-origins}")
+  private String corsAllowedOrigins;
+
+  @Bean
+  public WebMvcConfigurer addCorsConfig() {
+    return new WebMvcConfigurer() {
+      @Override
+      public void addCorsMappings(CorsRegistry registry) {
+        String[] originPatterns = corsAllowedOrigins.split(",");
+        registry.addMapping("/**")
+            .allowedMethods("*")
+            .allowedOriginPatterns(originPatterns)
+            .allowCredentials(true);
+      }
+    };
+  }
+}

--- a/src/main/java/com/_up/megastore/controllers/implementations/ProductController.java
+++ b/src/main/java/com/_up/megastore/controllers/implementations/ProductController.java
@@ -8,7 +8,6 @@ import com._up.megastore.services.interfaces.IProductService;
 import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
 import java.util.UUID;
 
 @RestController
@@ -24,12 +23,17 @@ public class ProductController implements IProductController {
     public ProductResponse saveProduct(CreateProductRequest createProductRequest, MultipartFile multipartFile) {
         return productService.saveProduct(createProductRequest, multipartFile);
     }
+
     @Override
     public ProductResponse updateProduct(UUID productId, UpdateProductRequest updateProductRequest, MultipartFile multipartFile){
        return productService.updateProduct(productId, updateProductRequest, multipartFile);
 
     }
 
+    @Override
+    public void deleteProduct(UUID productId) {
+        productService.deleteProduct(productId);
+    }
     @Override
     public ProductResponse restoreProduct(UUID productId) {
         return productService.restoreProduct(productId);

--- a/src/main/java/com/_up/megastore/controllers/implementations/UserController.java
+++ b/src/main/java/com/_up/megastore/controllers/implementations/UserController.java
@@ -1,0 +1,23 @@
+package com._up.megastore.controllers.implementations;
+
+import com._up.megastore.controllers.interfaces.IUserController;
+import com._up.megastore.controllers.requests.ActivateUserRequest;
+import com._up.megastore.services.implementations.UserService;
+import java.util.UUID;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class UserController implements IUserController {
+
+  private final UserService userService;
+
+  public UserController(UserService userService) {
+    this.userService = userService;
+  }
+
+  @Override
+  public void activateUser(UUID userId, ActivateUserRequest activateUserRequest) {
+    userService.activateUser(userId, activateUserRequest.activationToken());
+  }
+
+}

--- a/src/main/java/com/_up/megastore/controllers/interfaces/IProductController.java
+++ b/src/main/java/com/_up/megastore/controllers/interfaces/IProductController.java
@@ -10,7 +10,6 @@ import org.springframework.http.MediaType;
 import org.springframework.lang.Nullable;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-
 import java.util.UUID;
 
 @RequestMapping("/api/v1/products")
@@ -29,6 +28,12 @@ public interface IProductController {
             @PathVariable UUID productId,
             @RequestPart @Valid UpdateProductRequest updateProductRequest,
             @RequestPart @Nullable MultipartFile multipartFile
+    );
+
+    @DeleteMapping(value = "/{productId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    void deleteProduct(
+            @PathVariable UUID productId
     );
 
     @PostMapping("/{productId}/restore")

--- a/src/main/java/com/_up/megastore/controllers/interfaces/IUserController.java
+++ b/src/main/java/com/_up/megastore/controllers/interfaces/IUserController.java
@@ -1,0 +1,18 @@
+package com._up.megastore.controllers.interfaces;
+
+import com._up.megastore.controllers.requests.ActivateUserRequest;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequestMapping("/api/v1/users")
+public interface IUserController {
+
+  @PostMapping("/{userId}/activate")
+  void activateUser(@PathVariable UUID userId,
+      @RequestBody @Valid ActivateUserRequest activateUserRequest);
+
+}

--- a/src/main/java/com/_up/megastore/controllers/requests/ActivateUserRequest.java
+++ b/src/main/java/com/_up/megastore/controllers/requests/ActivateUserRequest.java
@@ -1,0 +1,11 @@
+package com._up.megastore.controllers.requests;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record ActivateUserRequest(
+    @NotNull(message = "Activation token must not be null")
+    UUID activationToken
+) {
+
+}

--- a/src/main/java/com/_up/megastore/data/model/User.java
+++ b/src/main/java/com/_up/megastore/data/model/User.java
@@ -52,7 +52,7 @@ public class User {
   private List<Order> orders = Collections.emptyList();
 
   private boolean deleted = false;
-  private boolean enabled = true;
+  private boolean activated = false;
   private final UUID activationToken = UUID.randomUUID();
 
   @Id

--- a/src/main/java/com/_up/megastore/data/model/User.java
+++ b/src/main/java/com/_up/megastore/data/model/User.java
@@ -52,6 +52,8 @@ public class User {
   private List<Order> orders = Collections.emptyList();
 
   private boolean deleted = false;
+  private boolean enabled = true;
+  private final UUID activationToken = UUID.randomUUID();
 
   @Id
   private final UUID userId = UUID.randomUUID();

--- a/src/main/java/com/_up/megastore/data/repositories/IUserRepository.java
+++ b/src/main/java/com/_up/megastore/data/repositories/IUserRepository.java
@@ -1,6 +1,7 @@
 package com._up.megastore.data.repositories;
 
 import com._up.megastore.data.model.User;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,4 +10,6 @@ public interface IUserRepository extends JpaRepository<User, UUID> {
   boolean existsByEmail(String email);
 
   boolean existsByUsername(String username);
+
+  Optional<User> findByUserIdAndActivationTokenAndActivatedIsFalse(UUID userId, UUID activationToken);
 }

--- a/src/main/java/com/_up/megastore/exception/custom_exceptions/EmailSendingException.java
+++ b/src/main/java/com/_up/megastore/exception/custom_exceptions/EmailSendingException.java
@@ -1,0 +1,9 @@
+package com._up.megastore.exception.custom_exceptions;
+
+public class EmailSendingException extends RuntimeException {
+
+  public EmailSendingException(String message) {
+    super(message);
+  }
+
+}

--- a/src/main/java/com/_up/megastore/services/implementations/EmailService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/EmailService.java
@@ -27,8 +27,8 @@ public class EmailService implements IEmailService {
       helper.setSubject(subject);
       helper.setText(content, true);
       javaMailSender.send(mimeMessage);
-    } catch (MessagingException ignored) {
-      throw new EmailSendingException("Failed to send e-mail");
+    } catch (MessagingException exception) {
+      throw new EmailSendingException("Failed to send e-mail: " + exception.getMessage());
     }
   }
 }

--- a/src/main/java/com/_up/megastore/services/implementations/EmailService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/EmailService.java
@@ -1,5 +1,6 @@
 package com._up.megastore.services.implementations;
 
+import com._up.megastore.exception.custom_exceptions.EmailSendingException;
 import com._up.megastore.services.interfaces.IEmailService;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
@@ -25,7 +26,9 @@ public class EmailService implements IEmailService {
       helper.setTo(to);
       helper.setSubject(subject);
       helper.setText(content, true);
+      javaMailSender.send(mimeMessage);
     } catch (MessagingException ignored) {
+      throw new EmailSendingException("Failed to send e-mail");
     }
   }
 }

--- a/src/main/java/com/_up/megastore/services/implementations/EmailService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/EmailService.java
@@ -1,0 +1,31 @@
+package com._up.megastore.services.implementations;
+
+import com._up.megastore.services.interfaces.IEmailService;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EmailService implements IEmailService {
+
+  private final JavaMailSender javaMailSender;
+
+  public EmailService(JavaMailSender javaMailSender) {
+    this.javaMailSender = javaMailSender;
+  }
+
+  @Override
+  public void sendEmail(String to, String subject, String content) {
+    MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+    MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, "utf-8");
+
+    try {
+      helper.setTo(to);
+      helper.setSubject(subject);
+      helper.setText(content, true);
+    } catch (MessagingException ignored) {
+    }
+  }
+}

--- a/src/main/java/com/_up/megastore/services/implementations/ProductService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/ProductService.java
@@ -55,6 +55,20 @@ public class ProductService implements IProductService {
                 .orElseThrow(() -> new NoSuchElementException("Product with id " + productId + " does not exist."));
     }
 
+    @Override
+    public void deleteProduct(UUID productId){
+        Product product = findProductByIdOrThrowException(productId);
+        ifProductIsNotDeletedThrowException(product);
+        product.setDeleted(true);
+        productRepository.save(product);
+    }
+
+    private void ifProductIsNotDeletedThrowException(Product product){
+        if (product.isDeleted()){
+            throw new IllegalStateException("Product with id " + product.getProductId() + " is already deleted.");
+        }
+    }
+
     private String saveProductImage(MultipartFile multipartFile) {
         return fileUploadService.uploadImage(multipartFile);
     }

--- a/src/main/java/com/_up/megastore/services/implementations/UserService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/UserService.java
@@ -42,6 +42,7 @@ public class UserService implements IUserService {
     User user = findUserToActivateOrThrowException(userId, activationToken);
     user.setActivated(true);
     userRepository.save(user);
+    sendWelcomeEmail(user);
   }
 
   User createUser(SignUpRequest createUserRequest) {
@@ -72,6 +73,19 @@ public class UserService implements IUserService {
         + "</table>";
 
     emailService.sendEmail(user.getEmail(), "Account activation", emailBody);
+  }
+
+  private void sendWelcomeEmail(User user) {
+    String emailBody = "<table style='width:100%; height:100%;'>"
+        + "<tr><td style='width:100%; height:100%; text-align:center; vertical-align:middle;'>"
+        + "<div style='display:inline-block;'>"
+        + "<h1>Welcome to Megastore</h1>"
+        + "<h3>Hey " + user.getFullName() + "!</h3>"
+        + "<h4>Your account has been activated.</h4>"
+        + "<p>Enjoy shopping with us!</p>"
+        + "</div></td></tr></table>";
+
+    emailService.sendEmail(user.getEmail(), "Welcome to Megastore", emailBody);
   }
 
   private void ifEmailAlreadyExistsThrowException(String email) {

--- a/src/main/java/com/_up/megastore/services/implementations/UserService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/UserService.java
@@ -3,18 +3,27 @@ package com._up.megastore.services.implementations;
 import com._up.megastore.controllers.requests.SignUpRequest;
 import com._up.megastore.data.model.User;
 import com._up.megastore.data.repositories.IUserRepository;
+import com._up.megastore.services.interfaces.IEmailService;
 import com._up.megastore.services.interfaces.IUserService;
 import com._up.megastore.services.mappers.UserMapper;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
 public class UserService implements IUserService {
 
+  private final IEmailService emailService;
   private final IUserRepository userRepository;
   private final PasswordEncoder passwordEncoder;
 
-  public UserService(IUserRepository userRepository, PasswordEncoder passwordEncoder) {
+  @Value("${frontend.url}")
+  private String frontendURL;
+
+  public UserService(IUserRepository userRepository, PasswordEncoder passwordEncoder,
+      IEmailService emailService) {
+    this.emailService = emailService;
     this.passwordEncoder = passwordEncoder;
     this.userRepository = userRepository;
   }
@@ -24,7 +33,15 @@ public class UserService implements IUserService {
     ifEmailAlreadyExistsThrowException(createUserRequest.email());
     ifUsernameAlreadyExistsThrowException(createUserRequest.username());
     User newUser = createUser(createUserRequest);
+    sendActivationEmail(newUser);
     userRepository.save(newUser);
+  }
+
+  @Override
+  public void activateUser(UUID userId, UUID activationToken) {
+    User user = findUserToActivateOrThrowException(userId, activationToken);
+    user.setActivated(true);
+    userRepository.save(user);
   }
 
   User createUser(SignUpRequest createUserRequest) {
@@ -32,6 +49,29 @@ public class UserService implements IUserService {
     String passwordEncoded = passwordEncoder.encode(createUserRequest.password());
     user.setPassword(passwordEncoded);
     return user;
+  }
+
+  private void sendActivationEmail(User user) {
+    String activationUrl = frontendURL + "/auth/activate?userId="
+        + user.getUserId() + "&activationToken=" + user.getActivationToken();
+
+    String emailBody = "<table style='width:100%; height:100%;'>"
+        + "<tr>"
+        + "<td style='width:100%; height:100%; text-align:center; vertical-align:middle;'>"
+        + "<div style='display:inline-block;'>"
+        + "<h1>Welcome to Megastore</h1>"
+        + "<h3>Hey " + user.getFullName() + "!</h3>"
+        + "<h4>Thanks for joining us!</h4>"
+        + "<p>Click the link below to activate your account</p>"
+        + "<a href=\""
+        + activationUrl
+        + "\">Activate account</a>"
+        + "</div>"
+        + "</td>"
+        + "</tr>"
+        + "</table>";
+
+    emailService.sendEmail(user.getEmail(), "Account activation", emailBody);
   }
 
   private void ifEmailAlreadyExistsThrowException(String email) {
@@ -45,4 +85,13 @@ public class UserService implements IUserService {
       throw new IllegalArgumentException("Username already exists");
     }
   }
+
+  private User findUserToActivateOrThrowException(UUID userId,
+      UUID activationToken) {
+    return userRepository.findByUserIdAndActivationTokenAndActivatedIsFalse(userId,
+            activationToken)
+        .orElseThrow(
+            () -> new IllegalArgumentException("Token is invalid or user is already activated"));
+  }
+
 }

--- a/src/main/java/com/_up/megastore/services/interfaces/IEmailService.java
+++ b/src/main/java/com/_up/megastore/services/interfaces/IEmailService.java
@@ -1,9 +1,6 @@
 package com._up.megastore.services.interfaces;
 
-import org.springframework.scheduling.annotation.Async;
-
 public interface IEmailService {
 
-  @Async
   void sendEmail(String to, String subject, String content);
 }

--- a/src/main/java/com/_up/megastore/services/interfaces/IEmailService.java
+++ b/src/main/java/com/_up/megastore/services/interfaces/IEmailService.java
@@ -1,0 +1,9 @@
+package com._up.megastore.services.interfaces;
+
+import org.springframework.scheduling.annotation.Async;
+
+public interface IEmailService {
+
+  @Async
+  void sendEmail(String to, String subject, String content);
+}

--- a/src/main/java/com/_up/megastore/services/interfaces/IProductService.java
+++ b/src/main/java/com/_up/megastore/services/interfaces/IProductService.java
@@ -15,6 +15,8 @@ public interface IProductService {
 
     Product findProductByIdOrThrowException(UUID productId);
 
+    void deleteProduct(UUID productId);
+
     ProductResponse updateProduct(UUID productId, UpdateProductRequest updateProductRequest, MultipartFile multipartFile);
 
     ProductResponse restoreProduct(UUID productId);

--- a/src/main/java/com/_up/megastore/services/interfaces/IUserService.java
+++ b/src/main/java/com/_up/megastore/services/interfaces/IUserService.java
@@ -1,8 +1,11 @@
 package com._up.megastore.services.interfaces;
 
 import com._up.megastore.controllers.requests.SignUpRequest;
+import java.util.UUID;
 
 public interface IUserService {
 
   void saveUser(SignUpRequest newUser);
+
+  void activateUser(UUID userId, UUID activationToken);
 }

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -4,6 +4,16 @@
       "name": "frontend.url",
       "type": "java.lang.String",
       "description": "Description for frontend.url."
+    },
+    {
+      "name": "app.url",
+      "type": "java.lang.String",
+      "description": "Description for app.url."
+    },
+    {
+      "name": "app.cors.allowed-origins",
+      "type": "java.lang.String",
+      "description": "Description for app.cors.allowed-origins."
     }
   ]
 }

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,9 @@
+{
+  "properties": [
+    {
+      "name": "frontend.url",
+      "type": "java.lang.String",
+      "description": "Description for frontend.url."
+    }
+  ]
+}

--- a/src/main/resources/application-development.yaml
+++ b/src/main/resources/application-development.yaml
@@ -12,3 +12,8 @@ spring:
 
 frontend:
   url: http://localhost:5173
+
+app:
+  url: http://localhost:8080
+  cors:
+    allowed-origins: http://localhost:5173

--- a/src/main/resources/application-development.yaml
+++ b/src/main/resources/application-development.yaml
@@ -2,3 +2,13 @@ cloudinary:
   cloud-name: dlomx8sc1
   api-key: 363723365928819
   api-secret: z1aLT2IRKpN97R8vMYNZAvFYG68
+
+spring:
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: 7up.megastore@gmail.com
+    password: kemb pmbj helh ikvn
+
+frontend:
+  url: http://localhost:5173

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -17,6 +17,17 @@ spring:
     port: ${MAIL_PORT}
     username: ${MAIL_USERNAME}
     password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
 
 frontend:
   url: ${FRONTEND_URL}
+
+app:
+  url: ${APP_URL}
+  cors:
+    allowed-origins: ${CORS_ALLOWED_ORIGINS}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,7 +8,7 @@ spring:
   datasource:
     url: jdbc:mysql://${DATASOURCE_URL:localhost:3306/megastore}
     username: ${DB_USERNAME:root}
-    password: ${DB_PASSWORD:123}
+    password: ${DB_PASSWORD:password}
     driver-class-name: com.mysql.cj.jdbc.Driver
   profiles:
     active: ${SPRING_PROFILE:development}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,7 +8,15 @@ spring:
   datasource:
     url: jdbc:mysql://${DATASOURCE_URL:localhost:3306/megastore}
     username: ${DB_USERNAME:root}
-    password: ${DB_PASSWORD:password}
+    password: ${DB_PASSWORD:123}
     driver-class-name: com.mysql.cj.jdbc.Driver
   profiles:
     active: ${SPRING_PROFILE:development}
+  mail:
+    host: ${MAIL_HOST}
+    port: ${MAIL_PORT}
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+
+frontend:
+  url: ${FRONTEND_URL}


### PR DESCRIPTION
Se implementó el envío de un mail de confirmación para activar la cuenta de un usuario.
Decidí implementar el UserController con el endpoint `/api/v1/users/{userId}/activate` porque me hacia mas sentido relacionarlo con la entidad usuario.

Ahora bien, el flujo es el siguiente:
- Se solicita el endpoint para crear un usuario.
- Se envía la confirmación del mail y se crea al usuario
- Si el envío falla, no se crea el usuario (debatible)
- Cuando el usuario ingresa al enlace que se le envió al mail, se redirige a una pagina del front que tiene un botón para realizar una petición de tipo POST al endpoint del UserController mencionado anteriormente.
- Si todo sale bien, como se ve en el gif, se redirecciona al usuario para logearse.
- Si sale mal, se muestra una alerta con el error definido en el backend.

## Funcionamiento ideal
![ezgif-7-111fd02b31](https://github.com/user-attachments/assets/cd1984b9-4e97-49b3-a613-226409ce267a)
## Muestra del error
![ezgif-7-37147f6be9](https://github.com/user-attachments/assets/d73ffde0-401e-49ff-a922-3b55c81d699a)

Me gustaría que todos mencionen que ven mal para un posible cambio o algún funcionamiento que vean que deba ser distinto.

# Actualización
El enlace del mail redirige al frontend y le envía unos datos por parámetros en la URL, estos son el token de activación y el id del usuario correspondiente. 
Con esta información, se puede hacer la peticion POST pasando el token como body. De esta forma, el backend puede validar si el token le corresponde a ese usuario y entonces activar la cuenta.