### PR TITLE
ref: multiple images

### DIFF
--- a/src/main/java/com/_up/megastore/controllers/implementations/ProductController.java
+++ b/src/main/java/com/_up/megastore/controllers/implementations/ProductController.java
@@ -20,13 +20,13 @@ public class ProductController implements IProductController {
     }
 
     @Override
-    public ProductResponse saveProduct(CreateProductRequest createProductRequest, MultipartFile multipartFile) {
-        return productService.saveProduct(createProductRequest, multipartFile);
+    public ProductResponse saveProduct(CreateProductRequest createProductRequest, MultipartFile[] multipartFiles) {
+        return productService.saveProduct(createProductRequest, multipartFiles);
     }
 
     @Override
-    public ProductResponse updateProduct(UUID productId, UpdateProductRequest updateProductRequest, MultipartFile multipartFile){
-       return productService.updateProduct(productId, updateProductRequest, multipartFile);
+    public ProductResponse updateProduct(UUID productId, UpdateProductRequest updateProductRequest, MultipartFile[] multipartFiles) {
+       return productService.updateProduct(productId, updateProductRequest, multipartFiles);
 
     }
 

--- a/src/main/java/com/_up/megastore/controllers/implementations/ProductController.java
+++ b/src/main/java/com/_up/megastore/controllers/implementations/ProductController.java
@@ -8,6 +8,7 @@ import com._up.megastore.services.interfaces.IProductService;
 import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+
 import java.util.UUID;
 
 @RestController

--- a/src/main/java/com/_up/megastore/controllers/interfaces/IProductController.java
+++ b/src/main/java/com/_up/megastore/controllers/interfaces/IProductController.java
@@ -19,7 +19,7 @@ public interface IProductController {
     @ResponseStatus(HttpStatus.CREATED)
     ProductResponse saveProduct(
             @RequestPart @Valid CreateProductRequest createProductRequest,
-            @RequestPart MultipartFile multipartFile
+            @RequestPart MultipartFile[] multipartFiles
     );
 
     @PatchMapping(value = "/{productId}", consumes = { MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE })
@@ -27,7 +27,7 @@ public interface IProductController {
     ProductResponse updateProduct(
             @PathVariable UUID productId,
             @RequestPart @Valid UpdateProductRequest updateProductRequest,
-            @RequestPart @Nullable MultipartFile multipartFile
+            @RequestPart @Nullable MultipartFile[] multipartFiles
     );
 
     @DeleteMapping(value = "/{productId}")

--- a/src/main/java/com/_up/megastore/controllers/interfaces/IProductController.java
+++ b/src/main/java/com/_up/megastore/controllers/interfaces/IProductController.java
@@ -10,6 +10,7 @@ import org.springframework.http.MediaType;
 import org.springframework.lang.Nullable;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
 import java.util.UUID;
 
 @RequestMapping("/api/v1/products")

--- a/src/main/java/com/_up/megastore/controllers/responses/ProductResponse.java
+++ b/src/main/java/com/_up/megastore/controllers/responses/ProductResponse.java
@@ -1,5 +1,6 @@
 package com._up.megastore.controllers.responses;
 
+import java.util.List;
 import java.util.UUID;
 
 public record ProductResponse(
@@ -7,7 +8,7 @@ public record ProductResponse(
         String name,
         String description,
         double price,
-        String imageURL,
+        List<String> imagesURLS,
         int stock,
         String color,
         String sizeName,

--- a/src/main/java/com/_up/megastore/data/model/Product.java
+++ b/src/main/java/com/_up/megastore/data/model/Product.java
@@ -24,7 +24,7 @@ public class Product {
     private Double price;
 
     @NonNull
-    private String imageURL;
+    private List<String> imagesURLS;
 
     @NonNull
     private Integer stock;

--- a/src/main/java/com/_up/megastore/data/model/Product.java
+++ b/src/main/java/com/_up/megastore/data/model/Product.java
@@ -24,9 +24,6 @@ public class Product {
     private Double price;
 
     @NonNull
-    private List<String> imagesURLS;
-
-    @NonNull
     private Integer stock;
 
     @NonNull
@@ -37,6 +34,9 @@ public class Product {
 
     @ManyToOne @NonNull
     private Category category;
+
+    @OneToMany @NonNull
+    private List<ProductImage> images;
 
     @ManyToOne
     private Product variantOf = null;

--- a/src/main/java/com/_up/megastore/data/model/ProductImage.java
+++ b/src/main/java/com/_up/megastore/data/model/ProductImage.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 
 @Entity(name = "productImages")
 @NoArgsConstructor
@@ -14,7 +15,10 @@ import lombok.NoArgsConstructor;
 @Data
 public class ProductImage {
 
+    @NonNull
+    private String name;
+
     @Id
-    private String imageURL;
+    private String url;
 
 }

--- a/src/main/java/com/_up/megastore/data/model/ProductImage.java
+++ b/src/main/java/com/_up/megastore/data/model/ProductImage.java
@@ -6,9 +6,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.NonNull;
-
-import java.util.UUID;
 
 @Entity(name = "productImages")
 @NoArgsConstructor
@@ -17,10 +14,7 @@ import java.util.UUID;
 @Data
 public class ProductImage {
 
-    @NonNull
-    private String imageURL;
-
     @Id
-    private final UUID productImageId = UUID.randomUUID();
+    private String imageURL;
 
 }

--- a/src/main/java/com/_up/megastore/data/model/ProductImage.java
+++ b/src/main/java/com/_up/megastore/data/model/ProductImage.java
@@ -1,0 +1,26 @@
+package com._up.megastore.data.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+import java.util.UUID;
+
+@Entity(name = "productImages")
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+public class ProductImage {
+
+    @NonNull
+    private String imageURL;
+
+    @Id
+    private final UUID productImageId = UUID.randomUUID();
+
+}

--- a/src/main/java/com/_up/megastore/data/repositories/IProductImageRepository.java
+++ b/src/main/java/com/_up/megastore/data/repositories/IProductImageRepository.java
@@ -1,0 +1,8 @@
+package com._up.megastore.data.repositories;
+
+import com._up.megastore.data.model.ProductImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface IProductImageRepository extends JpaRepository<ProductImage, UUID> {}

--- a/src/main/java/com/_up/megastore/data/repositories/IProductImageRepository.java
+++ b/src/main/java/com/_up/megastore/data/repositories/IProductImageRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
 
-public interface IProductImageRepository extends JpaRepository<ProductImage, UUID> {}
+public interface IProductImageRepository extends JpaRepository<ProductImage, UUID> {
+    boolean existsByName(String name);
+}

--- a/src/main/java/com/_up/megastore/services/implementations/ProductImageService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/ProductImageService.java
@@ -1,0 +1,27 @@
+package com._up.megastore.services.implementations;
+
+import com._up.megastore.data.model.ProductImage;
+import com._up.megastore.data.repositories.IProductImageRepository;
+import com._up.megastore.services.interfaces.IFileUploadService;
+import com._up.megastore.services.interfaces.IProductImageService;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+public class ProductImageService implements IProductImageService {
+
+    private final IFileUploadService fileUploadService;
+    private final IProductImageRepository productImageRepository;
+
+    public ProductImageService(IFileUploadService fileUploadService, IProductImageRepository productImageRepository) {
+        this.fileUploadService = fileUploadService;
+        this.productImageRepository = productImageRepository;
+    }
+
+    @Override
+    public ProductImage saveProductImage(MultipartFile multipartFile) {
+        String imageURL = fileUploadService.uploadImage(multipartFile);
+        return productImageRepository.save( new ProductImage(imageURL) );
+    }
+
+}

--- a/src/main/java/com/_up/megastore/services/implementations/ProductImageService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/ProductImageService.java
@@ -7,6 +7,10 @@ import com._up.megastore.services.interfaces.IProductImageService;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 public class ProductImageService implements IProductImageService {
 
@@ -19,7 +23,13 @@ public class ProductImageService implements IProductImageService {
     }
 
     @Override
-    public ProductImage saveProductImage(MultipartFile multipartFile) {
+    public List<ProductImage> saveProductImages(MultipartFile[] multipartFiles) {
+        return Arrays.stream(multipartFiles)
+                .map(this::saveProductImage)
+                .collect(Collectors.toList());
+    }
+
+    private ProductImage saveProductImage(MultipartFile multipartFile) {
         String imageURL = fileUploadService.uploadImage(multipartFile);
         return productImageRepository.save( new ProductImage(imageURL) );
     }

--- a/src/main/java/com/_up/megastore/services/implementations/ProductImageService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/ProductImageService.java
@@ -12,6 +12,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -34,10 +35,16 @@ public class ProductImageService implements IProductImageService {
     }
 
     private ProductImage saveProductImage(MultipartFile multipartFile) {
-        String name = multipartFile.getOriginalFilename();
+        String name = getImageFilename(multipartFile);
         ifImageNameAlreadyExistsThrowException(name);
         String imageURL = fileUploadService.uploadImage(multipartFile);
         return productImageRepository.save( new ProductImage(name, imageURL) );
+    }
+
+    private String getImageFilename(MultipartFile multipartFile) {
+        return Optional.ofNullable(multipartFile.getOriginalFilename())
+                .filter(name -> !name.isEmpty())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "The file must have a name."));
     }
 
     private void ifImageNameAlreadyExistsThrowException(String name) {

--- a/src/main/java/com/_up/megastore/services/implementations/ProductService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/ProductService.java
@@ -21,12 +21,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Service
 public class ProductService implements IProductService {
@@ -47,7 +44,7 @@ public class ProductService implements IProductService {
     public ProductResponse saveProduct(CreateProductRequest createProductRequest, MultipartFile[] multipartFiles) {
         Size size = sizeService.findSizeByIdOrThrowException(createProductRequest.sizeId());
         Category category = categoryService.findCategoryByIdOrThrowException(createProductRequest.categoryId());
-        List<ProductImage> images = saveProductImages(multipartFiles);
+        List<ProductImage> images = productImageService.saveProductImages(multipartFiles);
         Product variantOf = getVariantOf(createProductRequest.variantOfId());
 
         Product newProduct = ProductMapper.toProduct(createProductRequest, size, category, images, variantOf);
@@ -73,12 +70,6 @@ public class ProductService implements IProductService {
         if (product.isDeleted()){
             throw new IllegalStateException("Product with id " + product.getProductId() + " is already deleted.");
         }
-    }
-
-    private List<ProductImage> saveProductImages(MultipartFile[] multipartFiles) {
-        return Arrays.stream(multipartFiles)
-                .map(productImageService::saveProductImage)
-                .collect(Collectors.toList());
     }
 
     private Product getVariantOf(UUID variantOfId) {
@@ -128,11 +119,8 @@ public class ProductService implements IProductService {
 
     public void ifImagesExistsUpdateProductImagesURLs(MultipartFile[] multipartFiles, Product product) {
         if (multipartFiles != null) {
-            List<ProductImage> images = saveProductImages(multipartFiles);
-            product.setImages(
-                    Stream.concat(product.getImages().stream(), images.stream())
-                    .collect(Collectors.toList())
-            );
+            List<ProductImage> images = productImageService.saveProductImages(multipartFiles);
+            product.setImages(images);
         }
     }
 

--- a/src/main/java/com/_up/megastore/services/implementations/ProductService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/ProductService.java
@@ -88,7 +88,7 @@ public class ProductService implements IProductService {
         Product product = this.findProductByIdOrThrowException(productId);
         Category category = categoryService.findCategoryByIdOrThrowException(updateProductRequest.categoryId());
         ifVariantOfExistsUpdateProductVariantOf(updateProductRequest.variantOfId(), product);
-        ifImageURLExistsUpdateProductImageURL(multipartFiles, product);
+        ifImagesExistsUpdateProductImagesURLs(multipartFiles, product);
         product.setName(updateProductRequest.name());
         product.setDescription(updateProductRequest.description());
         product.setPrice(updateProductRequest.price());
@@ -124,7 +124,7 @@ public class ProductService implements IProductService {
         }
     }
 
-    public void ifImageURLExistsUpdateProductImageURL(MultipartFile[] multipartFiles, Product product){
+    public void ifImagesExistsUpdateProductImagesURLs(MultipartFile[] multipartFiles, Product product) {
         if (multipartFiles != null) {
             List<String> imagesURLS = saveProductImages(multipartFiles);
             product.setImagesURLS(

--- a/src/main/java/com/_up/megastore/services/interfaces/IProductImageService.java
+++ b/src/main/java/com/_up/megastore/services/interfaces/IProductImageService.java
@@ -1,0 +1,8 @@
+package com._up.megastore.services.interfaces;
+
+import com._up.megastore.data.model.ProductImage;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface IProductImageService {
+    ProductImage saveProductImage(MultipartFile multipartFile);
+}

--- a/src/main/java/com/_up/megastore/services/interfaces/IProductImageService.java
+++ b/src/main/java/com/_up/megastore/services/interfaces/IProductImageService.java
@@ -3,6 +3,8 @@ package com._up.megastore.services.interfaces;
 import com._up.megastore.data.model.ProductImage;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 public interface IProductImageService {
-    ProductImage saveProductImage(MultipartFile multipartFile);
+    List<ProductImage> saveProductImages(MultipartFile[] multipartFiles);
 }

--- a/src/main/java/com/_up/megastore/services/interfaces/IProductService.java
+++ b/src/main/java/com/_up/megastore/services/interfaces/IProductService.java
@@ -11,13 +11,13 @@ import java.util.UUID;
 
 public interface IProductService {
 
-    ProductResponse saveProduct(CreateProductRequest createProductRequest, MultipartFile multipartFile);
+    ProductResponse saveProduct(CreateProductRequest createProductRequest, MultipartFile[] multipartFiles);
 
     Product findProductByIdOrThrowException(UUID productId);
 
     void deleteProduct(UUID productId);
 
-    ProductResponse updateProduct(UUID productId, UpdateProductRequest updateProductRequest, MultipartFile multipartFile);
+    ProductResponse updateProduct(UUID productId, UpdateProductRequest updateProductRequest, MultipartFile[] multipartFiles);
 
     ProductResponse restoreProduct(UUID productId);
 

--- a/src/main/java/com/_up/megastore/services/mappers/ProductMapper.java
+++ b/src/main/java/com/_up/megastore/services/mappers/ProductMapper.java
@@ -6,6 +6,8 @@ import com._up.megastore.data.model.Category;
 import com._up.megastore.data.model.Product;
 import com._up.megastore.data.model.Size;
 
+import java.util.List;
+
 public class ProductMapper {
 
     public static ProductResponse toProductResponse(Product product) {
@@ -16,7 +18,7 @@ public class ProductMapper {
                 product.getName(),
                 product.getDescription(),
                 product.getPrice(),
-                product.getImageURL(),
+                product.getImagesURLS(),
                 product.getStock(),
                 product.getColor(),
                 product.getSize().getName(),
@@ -24,12 +26,12 @@ public class ProductMapper {
         );
     }
 
-    public static Product toProduct(CreateProductRequest createProductRequest, Size size, Category category, Product variantOf, String imageURL) {
+    public static Product toProduct(CreateProductRequest createProductRequest, Size size, Category category, Product variantOf, List<String> imagesURLS) {
         return Product.builder()
                 .name(createProductRequest.name())
                 .description(createProductRequest.description())
                 .price(createProductRequest.price())
-                .imageURL(imageURL)
+                .imagesURLS(imagesURLS)
                 .stock(createProductRequest.stock())
                 .color(createProductRequest.color())
                 .size(size)

--- a/src/main/java/com/_up/megastore/services/mappers/ProductMapper.java
+++ b/src/main/java/com/_up/megastore/services/mappers/ProductMapper.java
@@ -4,21 +4,24 @@ import com._up.megastore.controllers.requests.CreateProductRequest;
 import com._up.megastore.controllers.responses.ProductResponse;
 import com._up.megastore.data.model.Category;
 import com._up.megastore.data.model.Product;
+import com._up.megastore.data.model.ProductImage;
 import com._up.megastore.data.model.Size;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class ProductMapper {
 
     public static ProductResponse toProductResponse(Product product) {
         String variantName = getVariantName(product.getVariantOf());
+        List<String> imagesURLS = getImagesURLs(product);
 
         return new ProductResponse(
                 product.getProductId(),
                 product.getName(),
                 product.getDescription(),
                 product.getPrice(),
-                product.getImagesURLS(),
+                imagesURLS,
                 product.getStock(),
                 product.getColor(),
                 product.getSize().getName(),
@@ -26,16 +29,16 @@ public class ProductMapper {
         );
     }
 
-    public static Product toProduct(CreateProductRequest createProductRequest, Size size, Category category, Product variantOf, List<String> imagesURLS) {
+    public static Product toProduct(CreateProductRequest createProductRequest, Size size, Category category, List<ProductImage> images, Product variantOf) {
         return Product.builder()
                 .name(createProductRequest.name())
                 .description(createProductRequest.description())
                 .price(createProductRequest.price())
-                .imagesURLS(imagesURLS)
                 .stock(createProductRequest.stock())
                 .color(createProductRequest.color())
                 .size(size)
                 .category(category)
+                .images(images)
                 .variantOf(variantOf)
                 .build();
     }
@@ -44,5 +47,10 @@ public class ProductMapper {
         return variant != null ? variant.getName() : null;
     }
 
+    private static List<String> getImagesURLs(Product product) {
+        return product.getImages().stream()
+                .map(ProductImage::getImageURL)
+                .collect(Collectors.toList());
+    }
 
 }

--- a/src/main/java/com/_up/megastore/services/mappers/ProductMapper.java
+++ b/src/main/java/com/_up/megastore/services/mappers/ProductMapper.java
@@ -49,7 +49,7 @@ public class ProductMapper {
 
     private static List<String> getImagesURLs(Product product) {
         return product.getImages().stream()
-                .map(ProductImage::getImageURL)
+                .map(ProductImage::getUrl)
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
Se agregó la funcionalidad para registrar más de una imagen representativa de un producto, con el objetivo de permitir a los clientes visualizar en mayor detalle los productos.

Se modificaron dos operaciones:

- El **registrar producto**, que recibirá como parámetro **obligatorio** un array de MultipartFiles (si sólo se dispone de una imagen el array contendrá un elemento --no es obligatorio subir más de una imagen).
- El **actualizar producto**, que recibirá como parámetro **no obligatorio** un array de MultipartFiles. En caso de que este array exista, las nuevas imágenes se agregarán al producto y se sumarán a las anteriores.

Queda como deuda técnica la funcionalidad para eliminar las imágenes de un producto. 