### PR TITLE
fix: update supercategory

### DIFF
--- a/src/main/java/com/_up/megastore/services/implementations/CategoryService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/CategoryService.java
@@ -94,10 +94,12 @@ public class CategoryService implements ICategoryService {
         return CategoryMapper.toCategoryResponse(categoryRepository.save(category));
     }
 
-    public void ifSuperCategoryExistUpdateCategorySuperCategory(UUID superCategoryId, Category category){
-        if( superCategoryId != null && !superCategoryId.equals(category.getSuperCategory().getCategoryId() )){
+    public void ifSuperCategoryExistUpdateCategorySuperCategory(UUID superCategoryId, Category category) {
+        if (superCategoryId != null) {
             Category superCategory = findCategoryByIdOrThrowException(superCategoryId);
             category.setSuperCategory(superCategory);
+        } else {
+            category.setSuperCategory(null);
         }
     }
 


### PR DESCRIPTION
Se solucionó el bug de la actualización de super categorías. Anteriormente, cuando se intentaba actualizar la super categoría de una categoría que NO la tenía (esto es, su atributo era null), el método devolvía un NullPointerException.

Ahora se agregó una condición para que, si la ID de la supercategoría en el update request existe, se busque y se reemplace. En caso de no existir, la super categoría será reemplazada por un null. 