### PR TITLE
feat: product name validation

### DIFF
--- a/src/main/java/com/_up/megastore/controllers/requests/CreateProductRequest.java
+++ b/src/main/java/com/_up/megastore/controllers/requests/CreateProductRequest.java
@@ -1,5 +1,6 @@
 package com._up.megastore.controllers.requests;
 
+import com._up.megastore.data.pipes.ProductName;
 import jakarta.validation.constraints.*;
 
 import java.util.UUID;
@@ -8,6 +9,7 @@ public record CreateProductRequest(
 
         @NotBlank(message = "Product name must not be blank")
         @Size(max = 30, message = "Product name must be less than 30 characters")
+        @ProductName
         String name,
 
         @NotBlank(message = "Product description must not be blank")

--- a/src/main/java/com/_up/megastore/controllers/requests/UpdateProductRequest.java
+++ b/src/main/java/com/_up/megastore/controllers/requests/UpdateProductRequest.java
@@ -1,5 +1,6 @@
 package com._up.megastore.controllers.requests;
 
+import com._up.megastore.data.pipes.ProductName;
 import jakarta.validation.constraints.*;
 
 
@@ -9,6 +10,7 @@ import java.util.UUID;
 public record UpdateProductRequest(
     @NotBlank(message = "Product name must not be blank")
     @Size(max = 30, message = "Product name must be less than 30 characters")
+    @ProductName
     String name,
 
     @NotBlank(message = "Product description must not be blank")

--- a/src/main/java/com/_up/megastore/data/pipes/ProductName.java
+++ b/src/main/java/com/_up/megastore/data/pipes/ProductName.java
@@ -1,0 +1,22 @@
+package com._up.megastore.data.pipes;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = ProductNameValidator.class)
+public @interface ProductName {
+
+    String message() default "Product name already exists";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/main/java/com/_up/megastore/data/pipes/ProductNameValidator.java
+++ b/src/main/java/com/_up/megastore/data/pipes/ProductNameValidator.java
@@ -14,7 +14,7 @@ public class ProductNameValidator implements ConstraintValidator<ProductName, St
     @Override
     public boolean isValid(String s, ConstraintValidatorContext constraintValidatorContext) {
         if (s == null || s.isEmpty()) return true;
-        return !productRepository.existsByNameAndDeletedIsFalse(s);
+        return !productRepository.existsByNameIgnoreCaseAndDeletedIsFalse(s);
     }
 
 }

--- a/src/main/java/com/_up/megastore/data/pipes/ProductNameValidator.java
+++ b/src/main/java/com/_up/megastore/data/pipes/ProductNameValidator.java
@@ -1,0 +1,20 @@
+package com._up.megastore.data.pipes;
+
+import com._up.megastore.data.repositories.IProductRepository;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class ProductNameValidator implements ConstraintValidator<ProductName, String> {
+    private final IProductRepository productRepository;
+
+    public ProductNameValidator(IProductRepository productRepository) {
+        this.productRepository = productRepository;
+    }
+
+    @Override
+    public boolean isValid(String s, ConstraintValidatorContext constraintValidatorContext) {
+        if (s == null || s.isEmpty()) return true;
+        return !productRepository.existsByNameAndDeletedIsFalse(s);
+    }
+
+}

--- a/src/main/java/com/_up/megastore/data/repositories/IProductRepository.java
+++ b/src/main/java/com/_up/megastore/data/repositories/IProductRepository.java
@@ -10,4 +10,5 @@ import java.util.UUID;
 public interface IProductRepository extends JpaRepository<Product, UUID> {
     boolean existsByProductIdAndDeletedTrue(UUID productId);
     Page<Product> findProductsByDeletedIsFalseAndNameContainingIgnoreCase(String name, Pageable pageable);
+    boolean existsByName(String name);
 }

--- a/src/main/java/com/_up/megastore/data/repositories/IProductRepository.java
+++ b/src/main/java/com/_up/megastore/data/repositories/IProductRepository.java
@@ -10,5 +10,5 @@ import java.util.UUID;
 public interface IProductRepository extends JpaRepository<Product, UUID> {
     boolean existsByProductIdAndDeletedTrue(UUID productId);
     Page<Product> findProductsByDeletedIsFalseAndNameContainingIgnoreCase(String name, Pageable pageable);
-    boolean existsByName(String name);
+    boolean existsByNameAndDeletedIsFalse(String name);
 }

--- a/src/main/java/com/_up/megastore/data/repositories/IProductRepository.java
+++ b/src/main/java/com/_up/megastore/data/repositories/IProductRepository.java
@@ -10,5 +10,5 @@ import java.util.UUID;
 public interface IProductRepository extends JpaRepository<Product, UUID> {
     boolean existsByProductIdAndDeletedTrue(UUID productId);
     Page<Product> findProductsByDeletedIsFalseAndNameContainingIgnoreCase(String name, Pageable pageable);
-    boolean existsByNameAndDeletedIsFalse(String name);
+    boolean existsByNameIgnoreCaseAndDeletedIsFalse(String name);
 }

--- a/src/main/java/com/_up/megastore/services/implementations/ProductImageService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/ProductImageService.java
@@ -4,7 +4,6 @@ import com._up.megastore.data.model.ProductImage;
 import com._up.megastore.data.repositories.IProductImageRepository;
 import com._up.megastore.services.interfaces.IFileUploadService;
 import com._up.megastore.services.interfaces.IProductImageService;
-import jakarta.transaction.Transactional;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -27,7 +26,6 @@ public class ProductImageService implements IProductImageService {
     }
 
     @Override
-    @Transactional
     public List<ProductImage> saveProductImages(MultipartFile[] multipartFiles) {
         validateDuplicateImageNames(multipartFiles);
         return Arrays.stream(multipartFiles)

--- a/src/main/java/com/_up/megastore/services/implementations/ProductService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/ProductService.java
@@ -139,7 +139,7 @@ public class ProductService implements IProductService {
     }
 
     private void throwExceptionIfProductWithNameAlreadyExists(Product product) {
-        if (productRepository.existsByNameAndDeletedIsFalse(product.getName())) {
+        if (productRepository.existsByNameIgnoreCaseAndDeletedIsFalse(product.getName())) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Product with name " + product.getName()+ " already exists and is not deleted.");
         }
     }


### PR DESCRIPTION
Se agregó un método extra dentro del product service para validar que el producto que estemos por registrar (o actualizar) no tenga el nombre de otro producto ya existente. 

Por defecto, la implementación de los query methods de JPA (existsBy, findBy) respecto a los strings **no es case sensitive**, esto es, si quiero registrar un producto con el nombre "Camiseta Adidas" pero en la base de datos ya existe un producto con nombre "CAMISETA ADIDAS" se lanzará la excepción. A esto lo dejé así de forma intencional teniendo en cuenta los ejemplos que mostró el profe en clase.

Una interrogante que me surgió sobre esto es **cómo manejar la restauración de productos**. Si nosotros borramos un producto (lógicamente) y luego queremos registrar un nuevo producto que tenga el mismo nombre que el producto borrado, con esta implementación, se lanzará una excepción. Entonces, tenemos dos escenarios:

1. Dejar esta implementación, donde la excepción se lanzará por más que el producto esté borrado, o
2. Permitir registrar (o actualizar) productos cuyo nombre sea igual al de un producto borrado. En este caso, si queremos restaurar ese producto borrado debería lanzarse una excepción indicando que el producto que desea restaurar tiene el mismo nombre que un producto ya existente.

Pienso que la primera implementación nos evita tener registros duplicados en la base de datos pero la segunda quizás sea más cómoda en términos de experiencia de usuario. Me gustaría que a esto lo discutiéramos entre todos @Fedesan14 @delgadomatias @ValeLattanzi @martinjcrosetto @NicoAntu 