### PR TITLE
ref: async email sending

### DIFF
--- a/src/main/java/com/_up/megastore/MegastoreApplication.java
+++ b/src/main/java/com/_up/megastore/MegastoreApplication.java
@@ -2,8 +2,10 @@ package com._up.megastore;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
+@EnableAsync
 public class MegastoreApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(MegastoreApplication.class, args);

--- a/src/main/java/com/_up/megastore/services/interfaces/IEmailService.java
+++ b/src/main/java/com/_up/megastore/services/interfaces/IEmailService.java
@@ -1,6 +1,9 @@
 package com._up.megastore.services.interfaces;
 
+import org.springframework.scheduling.annotation.Async;
+
 public interface IEmailService {
 
+  @Async
   void sendEmail(String to, String subject, String content);
 }


### PR DESCRIPTION
Teniendo en cuenta que en nuestra implementación **no necesitamos esperar al envío de los correos**, es posible realizar esto de manera [asíncrona](https://medium.com/@dvikash1001/springboot-async-the-magic-and-the-gotchas-17f9471c6fe4) para mejorar el rendimiento y agilizar las peticiones. Por ello, se implementó el uso de las anotaciones para hacer asíncrono el envío de correos a través del Java Mail Sender.

Long story short, en Spring Boot, cuando se llama a un método asíncrono, este se ejecuta en un thread distinto del que se llamó, permitiendo a este último continuar con la siguiente tarea. Teniendo esto en cuenta, podemos devolver, por ejemplo, el 200 OK al usuario que se acaba de registrar sin esperar a que se envíe el correo electrónico, haciendo mucho más rápida la petición. Lo mismo aplica para el correo de bienvenida y muy posiblemente en un futuro para los correos de notificaciones.

