### PR TITLE
chore: cors preflight

### DIFF
--- a/src/main/java/com/_up/megastore/config/SecurityConfig.java
+++ b/src/main/java/com/_up/megastore/config/SecurityConfig.java
@@ -37,6 +37,7 @@ public class SecurityConfig {
         .authorizeHttpRequests(authRequest -> authRequest
             .requestMatchers(WHITE_LISTED_URLS).permitAll()
             .requestMatchers(HttpMethod.GET, ALLOWED_TO_GET_BY_USERS_URLS).permitAll()
+            .requestMatchers(HttpMethod.OPTIONS).permitAll()
             .requestMatchers(ALLOWED_TO_ADMINISTRATORS_URLS).hasRole(Role.ADMIN.name()))
         .sessionManagement(sessionManager -> sessionManager.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .httpBasic(Customizer.withDefaults())


### PR DESCRIPTION
Se agregó una configuración extra en Spring Security para soportar el [preflight](https://docs.sensedia.com/en/faqs/Latest/apis/preflight.html). En pocas palabras, el preflight es una operación HTTP OPTIONS que se envía antes de la request propia (por ejemplo, un POST) para verificar que el servidor acepte las condiciones de la request original antes de enviarla. Generalmente se utiliza en operaciones que contienen encabezados (como el Authorization).

En nuestro servidor, si bien permitimos el CORS, los endpoints están protegidos a la request OPTIONS, por lo que ante cualquier request (como guardar una categoría) se devolverá un 401. Dado que si el preflight no es aceptado la request original no se envía, esto hace que desde el front no podamos acceder a los recursos del back.

Opté por habilitar las requests de tipo OPTIONS a todos los endpoints. Esto es, obviamente, deuda técnica (desconozco la mejor práctica en estos casos), pero soluciona el problema provisoriamente.