### PR TITLE
feat: min validations

### DIFF
--- a/src/main/java/com/_up/megastore/controllers/requests/CreateCategoryRequest.java
+++ b/src/main/java/com/_up/megastore/controllers/requests/CreateCategoryRequest.java
@@ -8,11 +8,11 @@ import java.util.UUID;
 public record CreateCategoryRequest(
 
         @NotBlank(message = "Category name must not be blank")
-        @Size(max = 20, message = "Category name must be less than 20 characters")
+        @Size(min = 3, max = 20, message = "Category name must be between 3 and 20 characters")
         String name,
 
         @NotBlank(message = "Category description must not be blank")
-        @Size(max = 50, message = "Category description must be less than 50 characters")
+        @Size(min = 5, max = 50, message = "Category description must be between 5 and 50 characters")
         String description,
 
         UUID superCategoryId

--- a/src/main/java/com/_up/megastore/controllers/requests/CreateProductRequest.java
+++ b/src/main/java/com/_up/megastore/controllers/requests/CreateProductRequest.java
@@ -8,12 +8,12 @@ import java.util.UUID;
 public record CreateProductRequest(
 
         @NotBlank(message = "Product name must not be blank")
-        @Size(max = 30, message = "Product name must be less than 30 characters")
+        @Size(min = 3, max = 30, message = "Product name must be between 3 and 30 characters")
         @ProductName
         String name,
 
         @NotBlank(message = "Product description must not be blank")
-        @Size(max = 80, message = "Product description must be less than 80 characters")
+        @Size(min = 5, max = 80, message = "Product description must be between 5 and 80 characters")
         String description,
 
         @NotNull(message = "Product price must not be null")

--- a/src/main/java/com/_up/megastore/controllers/requests/CreateSizeRequest.java
+++ b/src/main/java/com/_up/megastore/controllers/requests/CreateSizeRequest.java
@@ -6,10 +6,10 @@ import jakarta.validation.constraints.Size;
 public record CreateSizeRequest(
 
         @NotNull(message = "Size name must not be null")
-        @Size(max = 20, message = "Size name must be less than 20 characters")
+        @Size(min = 3, max = 20, message = "Size name must be between 3 and 20 characters")
         String name,
 
         @NotNull(message = "Size description must not be null")
-        @Size(max = 50, message = "Size description must be less than 50 characters")
+        @Size(min = 5, max = 50, message = "Size description must be between 5 and 50 characters")
         String description
 ) {}

--- a/src/main/java/com/_up/megastore/controllers/requests/UpdateCategoryRequest.java
+++ b/src/main/java/com/_up/megastore/controllers/requests/UpdateCategoryRequest.java
@@ -7,11 +7,11 @@ import java.util.UUID;
 
 public record UpdateCategoryRequest(
         @NotBlank(message = "Category name must not be blank")
-        @Size(max = 20, message = "Category name must be less than 20 characters")
+        @Size(min = 3, max = 20, message = "Category name must be between 3 and 20 characters")
         String name,
 
         @NotBlank(message = "Category description must not be blank")
-        @Size(max = 50, message = "Category description must be less than 50 characters")
+        @Size(min = 5, max = 50, message = "Category description must be between 5 and 50 characters")
         String description,
 
         UUID superCategoryId

--- a/src/main/java/com/_up/megastore/controllers/requests/UpdateProductRequest.java
+++ b/src/main/java/com/_up/megastore/controllers/requests/UpdateProductRequest.java
@@ -9,12 +9,12 @@ import java.util.UUID;
 
 public record UpdateProductRequest(
     @NotBlank(message = "Product name must not be blank")
-    @Size(max = 30, message = "Product name must be less than 30 characters")
+    @Size(min = 3, max = 30, message = "Product name must be between 3 and 30 characters")
     @ProductName
     String name,
 
     @NotBlank(message = "Product description must not be blank")
-    @Size(max = 80, message = "Product description must be less than 80 characters")
+    @Size(min = 5, max = 80, message = "Product description must be between 5 and 80 characters")
     String description,
 
     @NotNull(message = "Product price must not be null")

--- a/src/main/java/com/_up/megastore/controllers/requests/UpdateSizeRequest.java
+++ b/src/main/java/com/_up/megastore/controllers/requests/UpdateSizeRequest.java
@@ -10,6 +10,6 @@ public record UpdateSizeRequest (
         String name,
 
         @NotNull(message = "Size description must not be null")
-        @Size(max = 50, message = "Size description must be less than 50 characters")
+        @Size(min = 5, max = 50, message = "Size description must be between 5 and 50 characters")
         String description
 ){}


### PR DESCRIPTION
Teniendo en cuenta lo mencionado en la [PR de administración de tamaños del front](https://github.com/7-Seven-Up/megastore-frontend/pull/15), se agregaron las validaciones de los mínimos para los tamaños, productos y categorías. 

Para no complicar las cosas, usé el siguiente lineamiento de forma global:

- 3 caracteres como mínimo para los **nombres**
- 5 caracteres como mínimo para la **descripción**