### PR TITLE
feat: resend activation email

### DIFF
--- a/src/main/java/com/_up/megastore/controllers/implementations/UserController.java
+++ b/src/main/java/com/_up/megastore/controllers/implementations/UserController.java
@@ -3,7 +3,7 @@ package com._up.megastore.controllers.implementations;
 import com._up.megastore.controllers.interfaces.IUserController;
 import com._up.megastore.controllers.requests.ActivateUserRequest;
 import com._up.megastore.controllers.requests.RecoverPasswordRequest;
-import com._up.megastore.controllers.requests.SendRecoverPasswordEmailRequest;
+import com._up.megastore.controllers.requests.SendEmailRequest;
 import com._up.megastore.services.implementations.UserService;
 
 import java.util.UUID;
@@ -24,12 +24,17 @@ public class UserController implements IUserController {
   }
 
   @Override
-  public void sendEmailToRecoverPassword(SendRecoverPasswordEmailRequest request) {
+  public void sendEmailToRecoverPassword(SendEmailRequest request) {
     userService.sendEmailToRecoverPassword(request.email());
   }
 
   @Override
   public void recoverPassword(RecoverPasswordRequest recoverPasswordRequest) {
     userService.recoverPassword( recoverPasswordRequest);
+  }
+
+  @Override
+  public void resendActivationEmail(SendEmailRequest sendEmailRequest) {
+    userService.resendActivationEmail(sendEmailRequest);
   }
 }

--- a/src/main/java/com/_up/megastore/controllers/interfaces/IUserController.java
+++ b/src/main/java/com/_up/megastore/controllers/interfaces/IUserController.java
@@ -2,7 +2,7 @@ package com._up.megastore.controllers.interfaces;
 
 import com._up.megastore.controllers.requests.ActivateUserRequest;
 import com._up.megastore.controllers.requests.RecoverPasswordRequest;
-import com._up.megastore.controllers.requests.SendRecoverPasswordEmailRequest;
+import com._up.megastore.controllers.requests.SendEmailRequest;
 import jakarta.validation.Valid;
 import java.util.UUID;
 
@@ -17,8 +17,11 @@ public interface IUserController {
       @RequestBody @Valid ActivateUserRequest activateUserRequest);
 
   @PostMapping("/recover-password/send-email") @ResponseStatus(HttpStatus.NO_CONTENT)
-  void sendEmailToRecoverPassword(@RequestBody SendRecoverPasswordEmailRequest sendRecoverPasswordEmailRequest);
+  void sendEmailToRecoverPassword(@RequestBody SendEmailRequest sendEmailRequest);
 
   @PostMapping("/recover-password") @ResponseStatus(HttpStatus.NO_CONTENT)
   void recoverPassword(@RequestBody RecoverPasswordRequest recoverPasswordRequest);
+
+  @PostMapping("/resend-activation-email")
+  void resendActivationEmail(@RequestBody SendEmailRequest sendEmailRequest);
 }

--- a/src/main/java/com/_up/megastore/controllers/requests/SendEmailRequest.java
+++ b/src/main/java/com/_up/megastore/controllers/requests/SendEmailRequest.java
@@ -2,7 +2,7 @@ package com._up.megastore.controllers.requests;
 
 import jakarta.validation.constraints.Email;
 
-public record SendRecoverPasswordEmailRequest(
+public record SendEmailRequest(
    @Email(message = "Invalid email")
    String email
 ) {}

--- a/src/main/java/com/_up/megastore/data/model/User.java
+++ b/src/main/java/com/_up/megastore/data/model/User.java
@@ -56,7 +56,7 @@ public class User {
 
   private boolean activated = false;
 
-  @OneToMany(cascade = {CascadeType.ALL})
+  @OneToMany(mappedBy = "user", cascade = {CascadeType.ALL})
   @Builder.Default
   private List<Token> activationTokens = Collections.emptyList();
 

--- a/src/main/java/com/_up/megastore/data/repositories/ITokenRepository.java
+++ b/src/main/java/com/_up/megastore/data/repositories/ITokenRepository.java
@@ -1,10 +1,18 @@
 package com._up.megastore.data.repositories;
 
 import com._up.megastore.data.model.Token;
+import com._up.megastore.data.model.User;
+import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import java.util.Optional;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
 import java.util.UUID;
 
 public interface ITokenRepository extends JpaRepository<Token, UUID> {
 
+    @Transactional
+    @Modifying
+    @Query("UPDATE tokens SET tokenExpirationDate = now() WHERE user = ?1")
+    void expireUserTokens(User user);
 }

--- a/src/main/java/com/_up/megastore/data/repositories/ITokenRepository.java
+++ b/src/main/java/com/_up/megastore/data/repositories/ITokenRepository.java
@@ -2,17 +2,15 @@ package com._up.megastore.data.repositories;
 
 import com._up.megastore.data.model.Token;
 import com._up.megastore.data.model.User;
-import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface ITokenRepository extends JpaRepository<Token, UUID> {
-
-    @Transactional
-    @Modifying
-    @Query("UPDATE tokens SET tokenExpirationDate = now() WHERE user = ?1")
-    void expireUserTokens(User user);
+    @Query("SELECT t FROM tokens t " +
+           "WHERE t.user = ?1 " +
+           "AND t.tokenExpirationDate > CURRENT_TIMESTAMP ")
+    Optional<Token> findActiveTokenByUser(User user);
 }

--- a/src/main/java/com/_up/megastore/security/utils/Endpoints.java
+++ b/src/main/java/com/_up/megastore/security/utils/Endpoints.java
@@ -6,7 +6,8 @@ public class Endpoints {
             "/auth/**",
             "/error",
             "/api/v1/users/*/activate",
-            "/api/v1/users/recover-password/*"
+            "/api/v1/users/recover-password/**",
+            "/api/v1/users/resend-activation-email"
     };
 
     public static String[] ALLOWED_TO_GET_BY_USERS_URLS = {

--- a/src/main/java/com/_up/megastore/services/implementations/TokenService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/TokenService.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Service

--- a/src/main/java/com/_up/megastore/services/implementations/TokenService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/TokenService.java
@@ -8,7 +8,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Service
@@ -38,5 +37,10 @@ public class TokenService implements ITokenService {
     public Token findTokenByIdOrThrowException(UUID token){
         return iTokenRepository.findById(token)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Token with UUID " + token + " does not exist."));
+    }
+
+    @Override
+    public void expireUserTokens(User user) {
+        iTokenRepository.expireUserTokens(user);
     }
 }

--- a/src/main/java/com/_up/megastore/services/implementations/TokenService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/TokenService.java
@@ -40,7 +40,8 @@ public class TokenService implements ITokenService {
     }
 
     @Override
-    public void expireUserTokens(User user) {
-        iTokenRepository.expireUserTokens(user);
+    public Token findActiveTokenByUser(User user) {
+        return iTokenRepository.findActiveTokenByUser(user)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "User activation token has expired"));
     }
 }

--- a/src/main/java/com/_up/megastore/services/implementations/UserService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/UserService.java
@@ -230,6 +230,7 @@ public class UserService implements IUserService {
   public void resendActivationEmail(SendEmailRequest sendEmailRequest) {
     User user = findUserByEmailOrThrowException(sendEmailRequest.email());
     ifUserIsActivatedThrowException(user);
+    tokenService.expireUserTokens(user);
     Token token = tokenService.saveToken(user);
     sendActivationEmail(user, token.getTokenId());
   }

--- a/src/main/java/com/_up/megastore/services/implementations/UserService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/UserService.java
@@ -10,14 +10,14 @@ import com._up.megastore.services.interfaces.IEmailService;
 import com._up.megastore.services.interfaces.ITokenService;
 import com._up.megastore.services.interfaces.IUserService;
 import com._up.megastore.services.mappers.UserMapper;
-import java.time.LocalDateTime;
-import java.util.UUID;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
 
 
 
@@ -230,8 +230,7 @@ public class UserService implements IUserService {
   public void resendActivationEmail(SendEmailRequest sendEmailRequest) {
     User user = findUserByEmailOrThrowException(sendEmailRequest.email());
     ifUserIsActivatedThrowException(user);
-    tokenService.expireUserTokens(user);
-    Token token = tokenService.saveToken(user);
+    Token token = tokenService.findActiveTokenByUser(user);
     sendActivationEmail(user, token.getTokenId());
   }
 

--- a/src/main/java/com/_up/megastore/services/implementations/UserService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/UserService.java
@@ -1,6 +1,7 @@
 package com._up.megastore.services.implementations;
 
 import com._up.megastore.controllers.requests.RecoverPasswordRequest;
+import com._up.megastore.controllers.requests.SendEmailRequest;
 import com._up.megastore.controllers.requests.SignUpRequest;
 import com._up.megastore.data.model.Token;
 import com._up.megastore.data.model.User;
@@ -127,7 +128,7 @@ public class UserService implements IUserService {
   }
   private void ifUserIsActivatedThrowException(User user){
     if(user.isActivated()){
-      throw new IllegalArgumentException("User with UUID " + user.getUserId() + " is already activated.");
+      throw new IllegalArgumentException("User is already activated.");
     }
   }
 
@@ -223,6 +224,14 @@ public class UserService implements IUserService {
   private void throwExceptionIfPasswordsAreNotEquals(String password, String confirmPassword) {
     if (!password.equals(confirmPassword))
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Passwords do not match");
+  }
+
+  @Override
+  public void resendActivationEmail(SendEmailRequest sendEmailRequest) {
+    User user = findUserByEmailOrThrowException(sendEmailRequest.email());
+    ifUserIsActivatedThrowException(user);
+    Token token = tokenService.saveToken(user);
+    sendActivationEmail(user, token.getTokenId());
   }
 
 }

--- a/src/main/java/com/_up/megastore/services/interfaces/ITokenService.java
+++ b/src/main/java/com/_up/megastore/services/interfaces/ITokenService.java
@@ -10,5 +10,5 @@ public interface ITokenService {
     public User findUserByActivationToken(UUID activationToken);
     public Token findTokenByIdOrThrowException(UUID token);
 
-    void expireUserTokens(User user);
+    Token findActiveTokenByUser(User user);
 }

--- a/src/main/java/com/_up/megastore/services/interfaces/ITokenService.java
+++ b/src/main/java/com/_up/megastore/services/interfaces/ITokenService.java
@@ -9,4 +9,6 @@ public interface ITokenService {
     public Token saveToken(User user);
     public User findUserByActivationToken(UUID activationToken);
     public Token findTokenByIdOrThrowException(UUID token);
+
+    void expireUserTokens(User user);
 }

--- a/src/main/java/com/_up/megastore/services/interfaces/IUserService.java
+++ b/src/main/java/com/_up/megastore/services/interfaces/IUserService.java
@@ -1,6 +1,7 @@
 package com._up.megastore.services.interfaces;
 
 import com._up.megastore.controllers.requests.RecoverPasswordRequest;
+import com._up.megastore.controllers.requests.SendEmailRequest;
 import com._up.megastore.controllers.requests.SignUpRequest;
 import com._up.megastore.data.model.User;
 import java.util.UUID;
@@ -15,4 +16,6 @@ public interface IUserService {
 
   void sendEmailToRecoverPassword(String email);
   void recoverPassword(RecoverPasswordRequest recoverPasswordRequest);
+
+  void resendActivationEmail(SendEmailRequest sendEmailRequest);
 }


### PR DESCRIPTION
Se agregó un endpoint para permitirles a los usuarios solicitar un nuevo token de activación. Con la generación de este nuevo token, los tokens anteriores se expirarán automáticamente para mantener el orden y la seguridad.

Algunas consideraciones:

- Se utilizó la misma plantilla de correo de activación utilizada en #2
- Para expirar los tokens automáticamente se utilizó un query method
- Se modificó la request de correo utilizada en #4 para aplicarla globalmente también a esta funcionalidad 