### PR TITLE
feat: resend expired activation

### DIFF
--- a/src/main/java/com/_up/megastore/controllers/implementations/UserController.java
+++ b/src/main/java/com/_up/megastore/controllers/implementations/UserController.java
@@ -4,10 +4,11 @@ import com._up.megastore.controllers.interfaces.IUserController;
 import com._up.megastore.controllers.requests.ActivateUserRequest;
 import com._up.megastore.controllers.requests.RecoverPasswordRequest;
 import com._up.megastore.controllers.requests.SendEmailRequest;
+import com._up.megastore.controllers.requests.SendNewActivationTokenRequest;
 import com._up.megastore.services.implementations.UserService;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.UUID;
-import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class UserController implements IUserController {
@@ -36,5 +37,10 @@ public class UserController implements IUserController {
   @Override
   public void resendActivationEmail(SendEmailRequest sendEmailRequest) {
     userService.resendActivationEmail(sendEmailRequest);
+  }
+
+  @Override
+  public void sendNewActivationToken(SendNewActivationTokenRequest sendNewActivationTokenRequest) {
+    userService.sendNewActivationToken(sendNewActivationTokenRequest);
   }
 }

--- a/src/main/java/com/_up/megastore/controllers/interfaces/IUserController.java
+++ b/src/main/java/com/_up/megastore/controllers/interfaces/IUserController.java
@@ -3,11 +3,16 @@ package com._up.megastore.controllers.interfaces;
 import com._up.megastore.controllers.requests.ActivateUserRequest;
 import com._up.megastore.controllers.requests.RecoverPasswordRequest;
 import com._up.megastore.controllers.requests.SendEmailRequest;
+import com._up.megastore.controllers.requests.SendNewActivationTokenRequest;
 import jakarta.validation.Valid;
-import java.util.UUID;
-
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.util.UUID;
 
 @RequestMapping("/api/v1/users")
 public interface IUserController {
@@ -24,4 +29,7 @@ public interface IUserController {
 
   @PostMapping("/resend-activation-email")
   void resendActivationEmail(@RequestBody SendEmailRequest sendEmailRequest);
+
+  @PostMapping("/send-new-activation-token")
+  void sendNewActivationToken(@RequestBody SendNewActivationTokenRequest sendNewActivationTokenRequest);
 }

--- a/src/main/java/com/_up/megastore/controllers/requests/SendNewActivationTokenRequest.java
+++ b/src/main/java/com/_up/megastore/controllers/requests/SendNewActivationTokenRequest.java
@@ -1,0 +1,10 @@
+package com._up.megastore.controllers.requests;
+
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.UUID;
+
+public record SendNewActivationTokenRequest(
+        @NotBlank(message = "Activation token must not be blank")
+        UUID activationToken
+) {}

--- a/src/main/java/com/_up/megastore/security/utils/Endpoints.java
+++ b/src/main/java/com/_up/megastore/security/utils/Endpoints.java
@@ -7,7 +7,8 @@ public class Endpoints {
             "/error",
             "/api/v1/users/*/activate",
             "/api/v1/users/recover-password/**",
-            "/api/v1/users/resend-activation-email"
+            "/api/v1/users/resend-activation-email",
+            "/api/v1/users/send-new-activation-token"
     };
 
     public static String[] ALLOWED_TO_GET_BY_USERS_URLS = {

--- a/src/main/java/com/_up/megastore/services/implementations/UserService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/UserService.java
@@ -2,6 +2,7 @@ package com._up.megastore.services.implementations;
 
 import com._up.megastore.controllers.requests.RecoverPasswordRequest;
 import com._up.megastore.controllers.requests.SendEmailRequest;
+import com._up.megastore.controllers.requests.SendNewActivationTokenRequest;
 import com._up.megastore.controllers.requests.SignUpRequest;
 import com._up.megastore.data.model.Token;
 import com._up.megastore.data.model.User;
@@ -18,8 +19,6 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
-
-
 
 @Service
 public class UserService implements IUserService {
@@ -232,6 +231,20 @@ public class UserService implements IUserService {
     ifUserIsActivatedThrowException(user);
     Token token = tokenService.findActiveTokenByUser(user);
     sendActivationEmail(user, token.getTokenId());
+  }
+
+  @Override
+  public void sendNewActivationToken(SendNewActivationTokenRequest sendNewActivationTokenRequest) {
+    throwExceptionIfTokenIsNotExpired(sendNewActivationTokenRequest.activationToken());
+    User user = tokenService.findUserByActivationToken(sendNewActivationTokenRequest.activationToken());
+    Token token = tokenService.saveToken(user);
+    sendActivationEmail(user, token.getTokenId());
+  }
+
+  private void throwExceptionIfTokenIsNotExpired(UUID activationTokenId) {
+    if (!isTokenExpired(activationTokenId)) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Token is not expired");
+    }
   }
 
 }

--- a/src/main/java/com/_up/megastore/services/implementations/UserService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/UserService.java
@@ -11,7 +11,7 @@ import com._up.megastore.services.interfaces.IEmailService;
 import com._up.megastore.services.interfaces.ITokenService;
 import com._up.megastore.services.interfaces.IUserService;
 import com._up.megastore.services.mappers.UserMapper;
-import org.springframework.beans.factory.annotation.Value;
+import com._up.megastore.utils.EmailBuilder;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -27,15 +27,15 @@ public class UserService implements IUserService {
   private final IUserRepository userRepository;
   private final PasswordEncoder passwordEncoder;
   private final ITokenService tokenService;
-  @Value("${frontend.url}")
-  private String frontendURL;
+  private final EmailBuilder emailBuilder;
 
   public UserService(IUserRepository userRepository, PasswordEncoder passwordEncoder,
-      IEmailService emailService, ITokenService tokenService) {
+                     IEmailService emailService, ITokenService tokenService, EmailBuilder emailBuilder) {
     this.emailService = emailService;
     this.passwordEncoder = passwordEncoder;
     this.userRepository = userRepository;
     this.tokenService = tokenService;
+    this.emailBuilder = emailBuilder;
   }
 
   @Override
@@ -73,38 +73,12 @@ public class UserService implements IUserService {
   }
 
   private void sendActivationEmail(User user, UUID activationToken) {
-    String activationUrl = frontendURL + "/auth/activate?userId="
-        + user.getUserId() + "&activationToken=" + activationToken;
-
-    String emailBody = "<table style='width:100%; height:100%;'>"
-        + "<tr>"
-        + "<td style='width:100%; height:100%; text-align:center; vertical-align:middle;'>"
-        + "<div style='display:inline-block;'>"
-        + "<h1>Welcome to Megastore</h1>"
-        + "<h3>Hey " + user.getFullName() + "!</h3>"
-        + "<h4>Thanks for joining us!</h4>"
-        + "<p>Click the link below to activate your account</p>"
-        + "<a href=\""
-        + activationUrl
-        + "\">Activate account</a>"
-        + "</div>"
-        + "</td>"
-        + "</tr>"
-        + "</table>";
-
+    String emailBody = emailBuilder.buildActivationEmailBody(user, activationToken);
     emailService.sendEmail(user.getEmail(), "Account activation", emailBody);
   }
 
   private void sendWelcomeEmail(User user) {
-    String emailBody = "<table style='width:100%; height:100%;'>"
-        + "<tr><td style='width:100%; height:100%; text-align:center; vertical-align:middle;'>"
-        + "<div style='display:inline-block;'>"
-        + "<h1>Welcome to Megastore</h1>"
-        + "<h3>Hey " + user.getFullName() + "!</h3>"
-        + "<h4>Your account has been activated.</h4>"
-        + "<p>Enjoy shopping with us!</p>"
-        + "</div></td></tr></table>";
-
+    String emailBody = emailBuilder.buildWelcomeEmail(user);
     emailService.sendEmail(user.getEmail(), "Welcome to Megastore", emailBody);
   }
 
@@ -152,52 +126,7 @@ public class UserService implements IUserService {
 
     userRepository.save(user);
 
-    String recoverPasswordURL = frontendURL + "/auth/recover-password?token=" + user.getRecoverPasswordToken();
-
-    String emailContent = "<!DOCTYPE html>\n"
-            + "<html>\n"
-            + "<head>\n"
-            + "    <meta charset=\"UTF-8\">\n"
-            + "    <title>Password Recovery</title>\n"
-            + "    <style>\n"
-            + "        body { font-family: Arial, sans-serif; }\n"
-            + "        .container { width: 80%; margin: 0 auto; }\n"
-            + "        .header { background-color: #f4f4f4; padding: 20px; text-align: center; }\n"
-            + "        .content { padding: 20px; }\n"
-            + "        .footer { background-color: #f4f4f4; padding: 10px; text-align: center; font-size: 12px; }\n"
-            + "        .button {\n"
-            + "            display: inline-block;\n"
-            + "            padding: 10px 20px;\n"
-            + "            font-size: 16px;\n"
-            + "            color: #fff;\n"
-            + "            background-color: #1ae866;\n"
-            + "            text-decoration: none;\n"
-            + "            border-radius: 5px;\n"
-            + "            text-align: center;\n"
-            + "        }\n"
-            + "        .button:hover {\n"
-            + "            background-color: #15d67c;\n"
-            + "        }\n"
-            + "    </style>\n"
-            + "</head>\n"
-            + "<body>\n"
-            + "    <div class=\"container\">\n"
-            + "        <div class=\"header\">\n"
-            + "            <h1>Password Recovery</h1>\n"
-            + "        </div>\n"
-            + "        <div class=\"content\">\n"
-            + "            <p>Hello " + user.getUsername() + ",</p>\n"
-            + "            <p>We received a request to reset your password. Click the button below to create a new password:</p>\n"
-            + "            <p style=\"display: flex; flex: content; justify-content: center;\"><a href=\" " + recoverPasswordURL + "\" class=\"button\">Reset Password</a></p>\n"
-            + "            <p>If you did not request this change, please ignore this email.</p>\n"
-            + "            <p>Best regards,<br>The Support Team</p>\n"
-            + "        </div>\n"
-            + "        <div class=\"footer\">\n"
-            + "            <p>Megastore, Villa Maria, Cordoba, Argentina</p>\n"
-            + "        </div>\n"
-            + "    </div>\n"
-            + "</body>\n"
-            + "</html>";
+    String emailContent = emailBuilder.buildRecoverPasswordEmail(user);
     emailService.sendEmail(email, "Recover Password", emailContent);
   }
 
@@ -238,7 +167,12 @@ public class UserService implements IUserService {
     throwExceptionIfTokenIsNotExpired(sendNewActivationTokenRequest.activationToken());
     User user = tokenService.findUserByActivationToken(sendNewActivationTokenRequest.activationToken());
     Token token = tokenService.saveToken(user);
-    sendActivationEmail(user, token.getTokenId());
+    sendNewActivationEmail(user, token.getTokenId());
+  }
+
+  private void sendNewActivationEmail(User user, UUID activationToken) {
+    String emailBody = emailBuilder.buildNewActivationEmail(user, activationToken);
+    emailService.sendEmail(user.getEmail(), "New Activation Token", emailBody);
   }
 
   private void throwExceptionIfTokenIsNotExpired(UUID activationTokenId) {

--- a/src/main/java/com/_up/megastore/services/interfaces/IUserService.java
+++ b/src/main/java/com/_up/megastore/services/interfaces/IUserService.java
@@ -2,6 +2,7 @@ package com._up.megastore.services.interfaces;
 
 import com._up.megastore.controllers.requests.RecoverPasswordRequest;
 import com._up.megastore.controllers.requests.SendEmailRequest;
+import com._up.megastore.controllers.requests.SendNewActivationTokenRequest;
 import com._up.megastore.controllers.requests.SignUpRequest;
 import com._up.megastore.data.model.User;
 import java.util.UUID;
@@ -18,4 +19,6 @@ public interface IUserService {
   void recoverPassword(RecoverPasswordRequest recoverPasswordRequest);
 
   void resendActivationEmail(SendEmailRequest sendEmailRequest);
+
+  void sendNewActivationToken(SendNewActivationTokenRequest sendNewActivationTokenRequest);
 }

--- a/src/main/java/com/_up/megastore/utils/EmailBuilder.java
+++ b/src/main/java/com/_up/megastore/utils/EmailBuilder.java
@@ -1,0 +1,116 @@
+package com._up.megastore.utils;
+
+import com._up.megastore.data.model.User;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+public class EmailBuilder {
+
+    @Value("${frontend.url}")
+    private String frontendURL;
+
+    public String buildActivationEmailBody(User user, UUID activationToken) {
+        String activationUrl = frontendURL + "/auth/activate?userId="
+                + user.getUserId() + "&activationToken=" + activationToken;
+
+        return "<table style='width:100%; height:100%;'>"
+                + "<tr>"
+                + "<td style='width:100%; height:100%; text-align:center; vertical-align:middle;'>"
+                + "<div style='display:inline-block;'>"
+                + "<h1>Welcome to Megastore</h1>"
+                + "<h3>Hey " + user.getFullName() + "!</h3>"
+                + "<h4>Thanks for joining us!</h4>"
+                + "<p>Click the link below to activate your account</p>"
+                + "<a href=\""
+                + activationUrl
+                + "\">Activate account</a>"
+                + "</div>"
+                + "</td>"
+                + "</tr>"
+                + "</table>";
+    }
+
+    public String buildRecoverPasswordEmail(User user) {
+        String recoverPasswordURL = frontendURL + "/auth/recover-password?token=" + user.getRecoverPasswordToken();
+
+        return "<!DOCTYPE html>\n"
+                + "<html>\n"
+                + "<head>\n"
+                + "    <meta charset=\"UTF-8\">\n"
+                + "    <title>Password Recovery</title>\n"
+                + "    <style>\n"
+                + "        body { font-family: Arial, sans-serif; }\n"
+                + "        .container { width: 80%; margin: 0 auto; }\n"
+                + "        .header { background-color: #f4f4f4; padding: 20px; text-align: center; }\n"
+                + "        .content { padding: 20px; }\n"
+                + "        .footer { background-color: #f4f4f4; padding: 10px; text-align: center; font-size: 12px; }\n"
+                + "        .button {\n"
+                + "            display: inline-block;\n"
+                + "            padding: 10px 20px;\n"
+                + "            font-size: 16px;\n"
+                + "            color: #fff;\n"
+                + "            background-color: #1ae866;\n"
+                + "            text-decoration: none;\n"
+                + "            border-radius: 5px;\n"
+                + "            text-align: center;\n"
+                + "        }\n"
+                + "        .button:hover {\n"
+                + "            background-color: #15d67c;\n"
+                + "        }\n"
+                + "    </style>\n"
+                + "</head>\n"
+                + "<body>\n"
+                + "    <div class=\"container\">\n"
+                + "        <div class=\"header\">\n"
+                + "            <h1>Password Recovery</h1>\n"
+                + "        </div>\n"
+                + "        <div class=\"content\">\n"
+                + "            <p>Hello " + user.getUsername() + ",</p>\n"
+                + "            <p>We received a request to reset your password. Click the button below to create a new password:</p>\n"
+                + "            <p style=\"display: flex; flex: content; justify-content: center;\"><a href=\" " + recoverPasswordURL + "\" class=\"button\">Reset Password</a></p>\n"
+                + "            <p>If you did not request this change, please ignore this email.</p>\n"
+                + "            <p>Best regards,<br>The Support Team</p>\n"
+                + "        </div>\n"
+                + "        <div class=\"footer\">\n"
+                + "            <p>Megastore, Villa Maria, Cordoba, Argentina</p>\n"
+                + "        </div>\n"
+                + "    </div>\n"
+                + "</body>\n"
+                + "</html>";
+    }
+
+    public String buildWelcomeEmail(User user) {
+        return "<table style='width:100%; height:100%;'>"
+                + "<tr><td style='width:100%; height:100%; text-align:center; vertical-align:middle;'>"
+                + "<div style='display:inline-block;'>"
+                + "<h1>Welcome to Megastore</h1>"
+                + "<h3>Hey " + user.getFullName() + "!</h3>"
+                + "<h4>Your account has been activated.</h4>"
+                + "<p>Enjoy shopping with us!</p>"
+                + "</div></td></tr></table>";
+    }
+
+    public String buildNewActivationEmail(User user, UUID activationToken) {
+        String activationUrl = frontendURL + "/auth/activate?userId="
+                + user.getUserId() + "&activationToken=" + activationToken;
+
+        return "<table style='width:100%; height:100%;'>"
+                + "<tr>"
+                + "<td style='width:100%; height:100%; text-align:center; vertical-align:middle;'>"
+                + "<div style='display:inline-block;'>"
+                + "<h2>Activation Token Request</h2>"
+                + "<h3>Hello " + user.getFullName() + "!</h3>"
+                + "<h4>We've received a request for a new activation token.</h4>"
+                + "<p>If you requested this, click the link below to activate your account:</p>"
+                + "<a href=\"" + activationUrl + "\">Activate account</a>"
+                + "<p>If you did not request this, please ignore this email.</p>"
+                + "</div>"
+                + "</td>"
+                + "</tr>"
+                + "</table>";
+    }
+
+}


### PR DESCRIPTION
Se agregó la funcionalidad para enviar un nuevo token de activación en caso de que a un usuario se le haya expirado su token. Como en un futuro vamos a refactorizar la funcionalidad para evitar mostrar las ID de los usuarios, lo único que recibiremos es el token (ya expirado) a través del cual buscaremos a un usuario y le enviaremos un nuevo token con un correo personalizado.

Me tomé también la libertad de refactorizar la **construcción de correos**. Separé los métodos de generación de bodies a una nueva clase personalizada: un _EmailBuilder_. Con esto dejamos un poco más limpio al UserService

## Ya sé

En un futuro habría que agregar un nuevo endpoint para recibir también las solicitudes de nuevos tokens de activación a través del correo electrónico. Esta implementación en particular funciona para cuando el usuario está en la pantalla de **activar usuario** y ve que su token está expirado. (https://github.com/7-Seven-Up/megastore-frontend/pull/20). Lo mencionado recién lo dejo como deuda técnica porque tengo ganas de jugar al haxball