### PR TITLE
fix: delete product with variants

### DIFF
--- a/src/main/java/com/_up/megastore/data/model/Product.java
+++ b/src/main/java/com/_up/megastore/data/model/Product.java
@@ -43,7 +43,7 @@ public class Product {
 
     private boolean deleted = false;
 
-    @OneToMany(mappedBy = "productId", cascade = {CascadeType.ALL})
+    @OneToMany(mappedBy = "variantOf", cascade = {CascadeType.ALL})
     private List<Product> variants = Collections.emptyList();
 
     @OneToMany(mappedBy = "product")

--- a/src/main/java/com/_up/megastore/data/repositories/IProductRepository.java
+++ b/src/main/java/com/_up/megastore/data/repositories/IProductRepository.java
@@ -11,4 +11,5 @@ public interface IProductRepository extends JpaRepository<Product, UUID> {
     boolean existsByProductIdAndDeletedTrue(UUID productId);
     Page<Product> findProductsByDeletedIsFalseAndNameContainingIgnoreCase(String name, Pageable pageable);
     boolean existsByNameIgnoreCaseAndDeletedIsFalse(String name);
+    boolean existsByVariantOfAndDeletedFalse(Product variantOf);
 }

--- a/src/main/java/com/_up/megastore/services/implementations/ProductService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/ProductService.java
@@ -72,7 +72,7 @@ public class ProductService implements IProductService {
     }
 
     private void throwExceptionIfProductHasVariants(Product product) {
-        if (!product.getVariants().isEmpty()) {
+        if (productRepository.existsByVariantOfAndDeletedFalse(product)) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Product with name " + product.getName() + " has variants and it can't be deleted.");
         }
     }

--- a/src/main/java/com/_up/megastore/services/implementations/ProductService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/ProductService.java
@@ -63,9 +63,18 @@ public class ProductService implements IProductService {
     @Override
     public void deleteProduct(UUID productId){
         Product product = findProductByIdOrThrowException(productId);
+
+        throwExceptionIfProductHasVariants(product);
         ifProductIsNotDeletedThrowException(product);
+
         product.setDeleted(true);
         productRepository.save(product);
+    }
+
+    private void throwExceptionIfProductHasVariants(Product product) {
+        if (!product.getVariants().isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Product with name " + product.getName() + " has variants and it can't be deleted.");
+        }
     }
 
     private void ifProductIsNotDeletedThrowException(Product product){


### PR DESCRIPTION
Se agregó la funcionalidad para evitar borrar productos que contengan variantes (siempre y cuando estas no estén ya borradas). Se utilizó un query method justamente para tener en cuenta este borrado lógico.