### PR TITLE
fix: minimum-length-category-description

### DIFF
--- a/src/main/java/com/_up/megastore/controllers/requests/CreateCategoryRequest.java
+++ b/src/main/java/com/_up/megastore/controllers/requests/CreateCategoryRequest.java
@@ -13,7 +13,7 @@ public record CreateCategoryRequest(
         String name,
 
         @NotBlank(message = "Category description must not be blank")
-        @Size(min = 5, max = 50, message = "Category description must be between 5 and 50 characters")
+        @Size(max = 50, message = "Category description must be less than 50 characters")
         String description,
 
         UUID superCategoryId

--- a/src/main/java/com/_up/megastore/controllers/requests/UpdateCategoryRequest.java
+++ b/src/main/java/com/_up/megastore/controllers/requests/UpdateCategoryRequest.java
@@ -12,7 +12,7 @@ public record UpdateCategoryRequest(
         String name,
 
         @NotBlank(message = "Category description must not be blank")
-        @Size(min = 5, max = 50, message = "Category description must be between 5 and 50 characters")
+        @Size(max = 50, message = "Category description must be less than 50 characters")
         String description,
 
         UUID superCategoryId


### PR DESCRIPTION
Se realizaron cambios en tanto en el CreateCategoryRequest como UpdateCategoryRequest, para que no valide  el tamaño minimo de la descripcion de la categoría.