### PR TITLE
fix: float mapping

### DIFF
--- a/src/main/java/com/_up/megastore/config/AuthConfig.java
+++ b/src/main/java/com/_up/megastore/config/AuthConfig.java
@@ -46,6 +46,7 @@ public class AuthConfig {
     var mapper = new ObjectMapper();
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     mapper.configure(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES, false);
+    mapper.configure(DeserializationFeature.ACCEPT_FLOAT_AS_INT, false);
     mapper.registerModule(new JavaTimeModule());
     return mapper;
   }

--- a/src/main/java/com/_up/megastore/exception/ExceptionControllerAdvice.java
+++ b/src/main/java/com/_up/megastore/exception/ExceptionControllerAdvice.java
@@ -1,14 +1,19 @@
 package com._up.megastore.exception;
 
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import org.springframework.dao.DataIntegrityViolationException;
-import java.time.LocalDateTime;
-import java.util.NoSuchElementException;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.NoSuchElementException;
+
+import static com._up.megastore.exception.ExceptionMessages.INVALID_FORMAT_EXCEPTION_MESSAGE;
 
 @RestControllerAdvice
 public class ExceptionControllerAdvice {
@@ -78,6 +83,29 @@ public class ExceptionControllerAdvice {
                 LocalDateTime.now(),
                 ex.getStackTrace()
         );
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ExceptionPayload handleHttpMessageNoReadableException(HttpMessageNotReadableException ex) {
+      return switch (ex.getCause()) {
+          case InvalidFormatException e -> handleInvalidFormatException(e);
+          default -> new ExceptionPayload(
+                  ex.getMessage(),
+                  HttpStatus.BAD_REQUEST.value(),
+                  LocalDateTime.now(),
+                  ex.getStackTrace()
+          );
+      };
+    }
+
+    private ExceptionPayload handleInvalidFormatException(InvalidFormatException ex) {
+      return new ExceptionPayload(
+              INVALID_FORMAT_EXCEPTION_MESSAGE,
+              HttpStatus.BAD_REQUEST.value(),
+              LocalDateTime.now(),
+              ex.getStackTrace()
+      );
     }
 
 }

--- a/src/main/java/com/_up/megastore/exception/ExceptionMessages.java
+++ b/src/main/java/com/_up/megastore/exception/ExceptionMessages.java
@@ -1,0 +1,5 @@
+package com._up.megastore.exception;
+
+public class ExceptionMessages {
+    public static String INVALID_FORMAT_EXCEPTION_MESSAGE = "Can't parse float values to integers";
+}


### PR DESCRIPTION
Esta PR está relacionada a la issue #91. Para solucionar este problema, agregué una configuración extra en el Jackson Mapper y cacheé las excepciones correspondientes.

## Exceptions

Para cada error ocurrido en el serializador, se lanza un HttpMessageNoReadableException. Como esta excepción es sumamente general y no tiene sentido manejarla de forma global, los mensajes de respuesta se enviarán según la excepción que la haya **causado**. Para ello, decidí usar un switch-case puesto que en un futuro podríamos manejar más excepciones causantes.

El enfoque mencionado en la parte de arriba podría utilizarse también para manejar el error que ocurre cuando subimos a Cloudinary una imagen mayor al límite.