### PR TITLE
ref: get products

### DIFF
--- a/src/main/java/com/_up/megastore/controllers/implementations/ProductController.java
+++ b/src/main/java/com/_up/megastore/controllers/implementations/ProductController.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -43,6 +44,11 @@ public class ProductController implements IProductController {
     @Override
     public ProductResponse getProduct(UUID productId) {
         return productService.getProduct(productId);
+    }
+
+    @Override
+    public List<ProductResponse> getProductVariants(UUID productId) {
+        return productService.getProductVariants(productId);
     }
 
     @Override

--- a/src/main/java/com/_up/megastore/controllers/interfaces/IProductController.java
+++ b/src/main/java/com/_up/megastore/controllers/interfaces/IProductController.java
@@ -8,9 +8,18 @@ import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.lang.Nullable;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
 import java.util.UUID;
 
 @RequestMapping("/api/v1/products")
@@ -44,6 +53,10 @@ public interface IProductController {
     @GetMapping("/{productId}")
     @ResponseStatus(HttpStatus.OK)
     ProductResponse getProduct(@PathVariable UUID productId);
+
+    @GetMapping("/{productId}/variants")
+    @ResponseStatus(HttpStatus.OK)
+    List<ProductResponse> getProductVariants(@PathVariable UUID productId);
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/java/com/_up/megastore/data/repositories/IProductRepository.java
+++ b/src/main/java/com/_up/megastore/data/repositories/IProductRepository.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 
 public interface IProductRepository extends JpaRepository<Product, UUID> {
     boolean existsByProductIdAndDeletedTrue(UUID productId);
-    Page<Product> findProductsByDeletedIsFalseAndNameContainingIgnoreCase(String name, Pageable pageable);
+    Page<Product> findProductsByDeletedIsFalseAndVariantOfIsNullAndNameContainingIgnoreCase(String name, Pageable pageable);
     boolean existsByNameIgnoreCaseAndDeletedIsFalse(String name);
     boolean existsByVariantOfAndDeletedFalse(Product variantOf);
     List<Product> findProductByVariantOfAndDeletedFalse(Product variantOf);

--- a/src/main/java/com/_up/megastore/data/repositories/IProductRepository.java
+++ b/src/main/java/com/_up/megastore/data/repositories/IProductRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface IProductRepository extends JpaRepository<Product, UUID> {
@@ -12,4 +13,5 @@ public interface IProductRepository extends JpaRepository<Product, UUID> {
     Page<Product> findProductsByDeletedIsFalseAndNameContainingIgnoreCase(String name, Pageable pageable);
     boolean existsByNameIgnoreCaseAndDeletedIsFalse(String name);
     boolean existsByVariantOfAndDeletedFalse(Product variantOf);
+    List<Product> findProductByVariantOfAndDeletedFalse(Product variantOf);
 }

--- a/src/main/java/com/_up/megastore/services/implementations/ProductService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/ProductService.java
@@ -25,6 +25,7 @@ import org.springframework.web.server.ResponseStatusException;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 public class ProductService implements IProductService {
@@ -115,6 +116,14 @@ public class ProductService implements IProductService {
     @Override
     public ProductResponse getProduct(UUID productId) {
         return ProductMapper.toProductResponse(findProductByIdOrThrowException(productId));
+    }
+
+    @Override
+    public List<ProductResponse> getProductVariants(UUID productId) {
+        Product product = findProductByIdOrThrowException(productId);
+        return productRepository.findProductByVariantOfAndDeletedFalse(product).stream()
+                .map(ProductMapper::toProductResponse)
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/com/_up/megastore/services/implementations/ProductService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/ProductService.java
@@ -129,7 +129,7 @@ public class ProductService implements IProductService {
     @Override
     public Page<ProductResponse> getProducts(int page, int pageSize, String name) {
         Pageable pageable = PageRequest.of(page, pageSize);
-        return productRepository.findProductsByDeletedIsFalseAndNameContainingIgnoreCase(name, pageable)
+        return productRepository.findProductsByDeletedIsFalseAndVariantOfIsNullAndNameContainingIgnoreCase(name, pageable)
                 .map(ProductMapper::toProductResponse);
     }
 

--- a/src/main/java/com/_up/megastore/services/interfaces/IProductService.java
+++ b/src/main/java/com/_up/megastore/services/interfaces/IProductService.java
@@ -7,6 +7,7 @@ import com._up.megastore.data.model.Product;
 import org.springframework.data.domain.Page;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface IProductService {
@@ -22,6 +23,9 @@ public interface IProductService {
     ProductResponse restoreProduct(UUID productId);
 
     ProductResponse getProduct(UUID productId);
+
+    List<ProductResponse> getProductVariants(UUID productId);
+
     Page<ProductResponse> getProducts(int page, int pageSize, String name);
 
 }

--- a/src/test/java/com/_up/megastore/integrations/base/BaseIntegrationTest.java
+++ b/src/test/java/com/_up/megastore/integrations/base/BaseIntegrationTest.java
@@ -25,7 +25,16 @@ public class BaseIntegrationTest {
     }
 
     protected void assertContains(String response, String propertyName, String value) {
-        String valueToCheck = "\"" + propertyName + "\"" + ":" + "\"" + value + "\"";
+        String valueToCheck = buildValueToCheck(propertyName, value);
         Assertions.assertTrue(response.contains(valueToCheck));
+    }
+
+    protected void assertNotContains(String response, String propertyName, String value) {
+        String valueToCheck = buildValueToCheck(propertyName, value);
+        Assertions.assertFalse(response.contains(valueToCheck));
+    }
+
+    private String buildValueToCheck(String propertyName, String value) {
+        return "\"" + propertyName + "\"" + ":" + "\"" + value + "\"";
     }
 }

--- a/src/test/java/com/_up/megastore/integrations/implementations/ProductControllerTest.java
+++ b/src/test/java/com/_up/megastore/integrations/implementations/ProductControllerTest.java
@@ -1,0 +1,27 @@
+package com._up.megastore.integrations.implementations;
+
+import com._up.megastore.integrations.base.BaseIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Sql("/scripts/products/get_variants.sql")
+class ProductControllerTest extends BaseIntegrationTest {
+
+    @Test
+    void getProductVariants() throws Exception {
+        String response = mockMvc.perform(
+                        get("/api/v1/products/183f205a-3430-4e11-8bca-57672a0ce3ff/variants")
+                                .contentType(MediaType.APPLICATION_JSON)
+                ).andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        assertContains(response, "name", "Variant name");
+        assertContains(response, "description", "Variant description");
+    }
+}

--- a/src/test/java/com/_up/megastore/integrations/implementations/ProductControllerTest.java
+++ b/src/test/java/com/_up/megastore/integrations/implementations/ProductControllerTest.java
@@ -23,5 +23,25 @@ class ProductControllerTest extends BaseIntegrationTest {
 
         assertContains(response, "name", "Variant name");
         assertContains(response, "description", "Variant description");
+
+        assertNotContains(response, "name", "Product name");
+        assertNotContains(response, "description", "Product description");
+    }
+
+    @Test
+    void getProducts() throws Exception {
+        String response = mockMvc.perform(
+                        get("/api/v1/products")
+                                .contentType(MediaType.APPLICATION_JSON)
+                ).andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        assertContains(response, "name", "Product name");
+        assertContains(response, "description", "Product description");
+
+        assertNotContains(response, "name", "Variant name");
+        assertNotContains(response, "description", "Variant description");
     }
 }

--- a/src/test/resources/scripts/products/get_variants.sql
+++ b/src/test/resources/scripts/products/get_variants.sql
@@ -1,0 +1,21 @@
+INSERT INTO sizes (size_id, name, description, deleted)
+VALUES ('03f667f7-4075-41f1-a35d-b4dc71f05b8a', 'Size name', 'Size description', FALSE);
+
+INSERT INTO categories (category_id, name, description, super_category_category_id, deleted)
+VALUES ('0bbad5ac-3986-4832-8a87-0141a83052ce', 'Category name', 'Category description', null, false);
+
+INSERT INTO product_images (url, name)
+VALUES ('url 1', 'image 1'),
+       ('url 2', 'image 2'),
+       ('url 3', 'image 3');
+
+INSERT INTO products (product_id, name, description, price, stock, color, size_size_id, category_category_id, deleted)
+VALUES ('183f205a-3430-4e11-8bca-57672a0ce3ff', 'Product name', 'Product description', 10000.0, 10, '#ffffff', '03f667f7-4075-41f1-a35d-b4dc71f05b8a', '0bbad5ac-3986-4832-8a87-0141a83052ce', false);
+
+INSERT INTO products (product_id, name, description, price, stock, color, variant_of_product_id, size_size_id, category_category_id, deleted)
+VALUES ('22ede130-726f-49ac-9564-d783fc22a6fa', 'Variant name', 'Variant description', 10000.0, 10, '#ffffff', '183f205a-3430-4e11-8bca-57672a0ce3ff', '03f667f7-4075-41f1-a35d-b4dc71f05b8a', '0bbad5ac-3986-4832-8a87-0141a83052ce', false);
+
+INSERT INTO products_images (products_product_id, images_url)
+VALUES ('183f205a-3430-4e11-8bca-57672a0ce3ff', 'url 1'),
+       ('183f205a-3430-4e11-8bca-57672a0ce3ff', 'url 2'),
+       ('22ede130-726f-49ac-9564-d783fc22a6fa', 'url 3');


### PR DESCRIPTION
Se realizaron los siguientes cambios para agilizar la muestra de variables de los productos:

1. El endpoint /api/v1/products ahora devuelve únicamente productos que NO tengan super-producto, esto es, no devuelve variantes
2. Se agregó un nuevo endpoint /api/v1/products/{id}/variants para devolver una lista con las variantes de un producto

# Tests

Se realizaron los tests de integración correspondientes para estos métodos. Para ello, se creó un archivo .sql para cargar unos registros previos a la base de datos de testing.

Se crearon dos productos: un producto base (sin variantes) y una variante del producto base. Se testeó, entonces, que al pegarle a /api/v1/products sólo se devuelva el producto base y que al pegarle a /api/v1/products/{idDelBase}/variants sólo se devuelva la variante.

**PD**: el archivo .SQL se aplicó de manera global a la clase porque esta última es nueva y contiene sólo esos dos métodos. Si después queremos hacer un test distinto con otro script sql, podemos mover la anotación @Sql al método. 