### PR TITLE
feat: finish order

### DIFF
--- a/src/main/java/com/_up/megastore/controllers/implementations/OrderController.java
+++ b/src/main/java/com/_up/megastore/controllers/implementations/OrderController.java
@@ -6,6 +6,8 @@ import com._up.megastore.controllers.responses.OrderResponse;
 import com._up.megastore.services.interfaces.IOrderService;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.UUID;
+
 @RestController
 public class OrderController implements IOrderController {
 
@@ -18,6 +20,11 @@ public class OrderController implements IOrderController {
     @Override
     public OrderResponse saveOrder(CreateOrderRequest createOrderRequest) {
         return orderService.saveOrder(createOrderRequest);
+    }
+
+    @Override
+    public OrderResponse finishOrder(UUID orderId) {
+        return orderService.finishOrder(orderId);
     }
 
 }

--- a/src/main/java/com/_up/megastore/controllers/interfaces/IOrderController.java
+++ b/src/main/java/com/_up/megastore/controllers/interfaces/IOrderController.java
@@ -19,7 +19,7 @@ public interface IOrderController {
     OrderResponse saveOrder(@RequestBody CreateOrderRequest createOrderRequest);
 
     @PostMapping("/{orderId}/finish")
-    @ResponseStatus(HttpStatus.CREATED)
+    @ResponseStatus(HttpStatus.OK)
     OrderResponse finishOrder(@PathVariable UUID orderId);
 
 }

--- a/src/main/java/com/_up/megastore/controllers/interfaces/IOrderController.java
+++ b/src/main/java/com/_up/megastore/controllers/interfaces/IOrderController.java
@@ -3,10 +3,13 @@ package com._up.megastore.controllers.interfaces;
 import com._up.megastore.controllers.requests.CreateOrderRequest;
 import com._up.megastore.controllers.responses.OrderResponse;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.util.UUID;
 
 @RequestMapping("/api/v1/orders")
 public interface IOrderController {
@@ -14,5 +17,9 @@ public interface IOrderController {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     OrderResponse saveOrder(@RequestBody CreateOrderRequest createOrderRequest);
+
+    @PostMapping("/{orderId}/finish")
+    @ResponseStatus(HttpStatus.CREATED)
+    OrderResponse finishOrder(@PathVariable UUID orderId);
 
 }

--- a/src/main/java/com/_up/megastore/data/enums/State.java
+++ b/src/main/java/com/_up/megastore/data/enums/State.java
@@ -3,5 +3,7 @@ package com._up.megastore.data.enums;
 public enum State {
     IN_PROGRESS,
     FINISHED,
-    DELIVERED
+    IN_DELIVERY,
+    DELIVERED,
+    CANCELED
 }

--- a/src/main/java/com/_up/megastore/data/model/OrderDetail.java
+++ b/src/main/java/com/_up/megastore/data/model/OrderDetail.java
@@ -18,7 +18,7 @@ public class OrderDetail {
     private Integer quantity;
 
     @NonNull
-    private Double priceToDate;
+    private Double subtotal;
 
     @ManyToOne @NonNull
     private Product product;

--- a/src/main/java/com/_up/megastore/data/repositories/IOrderRepository.java
+++ b/src/main/java/com/_up/megastore/data/repositories/IOrderRepository.java
@@ -9,4 +9,7 @@ import java.util.UUID;
 public interface IOrderRepository extends JpaRepository<Order, UUID> {
     @Query("SELECT COALESCE(MAX(o.number), 0) FROM orders o")
     Integer getLastOrderNumber();
+
+    @Query("SELECT SUM(detail.subtotal) FROM orders o JOIN o.orderDetails detail WHERE o = ?1")
+    Double getOrderTotal(Order order);
 }

--- a/src/main/java/com/_up/megastore/services/implementations/OrderDetailService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/OrderDetailService.java
@@ -37,6 +37,7 @@ public class OrderDetailService implements IOrderDetailService {
     private OrderDetail saveOrderDetail(Order order, OrderDetailRequest orderDetailRequest) {
         Product product = productService.findProductByIdOrThrowException(orderDetailRequest.productId());
         productService.discountProductStock(orderDetailRequest.quantity(), product);
-        return orderDetailRepository.save( OrderDetailMapper.toOrderDetail(order, product, orderDetailRequest));
+        Double subtotal = product.getPrice() * orderDetailRequest.quantity();
+        return orderDetailRepository.save( OrderDetailMapper.toOrderDetail(order, product, subtotal, orderDetailRequest));
     }
 }

--- a/src/main/java/com/_up/megastore/services/interfaces/IOrderService.java
+++ b/src/main/java/com/_up/megastore/services/interfaces/IOrderService.java
@@ -2,9 +2,15 @@ package com._up.megastore.services.interfaces;
 
 import com._up.megastore.controllers.requests.CreateOrderRequest;
 import com._up.megastore.controllers.responses.OrderResponse;
+import com._up.megastore.data.model.Order;
+
+import java.util.UUID;
 
 public interface IOrderService {
 
     OrderResponse saveOrder(CreateOrderRequest createOrderRequest);
 
+    Order findOrderByIdOrThrowException(UUID orderId);
+
+    OrderResponse finishOrder(UUID orderId);
 }

--- a/src/main/java/com/_up/megastore/services/mappers/OrderDetailMapper.java
+++ b/src/main/java/com/_up/megastore/services/mappers/OrderDetailMapper.java
@@ -17,7 +17,7 @@ public class OrderDetailMapper {
                 .product(product)
                 .quantity(orderDetailRequest.quantity())
                 .order(order)
-                .priceToDate(product.getPrice())
+                .subtotal(product.getPrice() * orderDetailRequest.quantity())
                 .build();
     }
 

--- a/src/main/java/com/_up/megastore/services/mappers/OrderDetailMapper.java
+++ b/src/main/java/com/_up/megastore/services/mappers/OrderDetailMapper.java
@@ -11,13 +11,14 @@ public class OrderDetailMapper {
     public static OrderDetail toOrderDetail(
             Order order,
             Product product,
+            Double subtotal,
             OrderDetailRequest orderDetailRequest
     ) {
         return OrderDetail.builder()
                 .product(product)
                 .quantity(orderDetailRequest.quantity())
                 .order(order)
-                .subtotal(product.getPrice() * orderDetailRequest.quantity())
+                .subtotal(subtotal)
                 .build();
     }
 

--- a/src/main/java/com/_up/megastore/services/mappers/OrderMapper.java
+++ b/src/main/java/com/_up/megastore/services/mappers/OrderMapper.java
@@ -20,8 +20,7 @@ public class OrderMapper {
 
     public static OrderResponse toOrderResponse(
             Order order,
-            Double total,
-            List<OrderDetail> orderDetails) {
+            Double total) {
         return new OrderResponse(
                 order.getOrderId(),
                 order.getNumber(),
@@ -29,7 +28,7 @@ public class OrderMapper {
                 order.getUser().getFullName(),
                 order.getState().name(),
                 total,
-                buildOrderDetailsResponse(orderDetails)
+                buildOrderDetailsResponse(order.getOrderDetails())
         );
     }
 

--- a/src/main/java/com/_up/megastore/utils/EmailBuilder.java
+++ b/src/main/java/com/_up/megastore/utils/EmailBuilder.java
@@ -1,5 +1,6 @@
 package com._up.megastore.utils;
 
+import com._up.megastore.data.model.Order;
 import com._up.megastore.data.model.User;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -111,6 +112,21 @@ public class EmailBuilder {
                 + "</td>"
                 + "</tr>"
                 + "</table>";
+    }
+
+    public String buildFinishOrderEmail(Order order) {
+        String orderDetailUrl = frontendURL + "/orders/" + order.getOrderId();
+
+        return "<table style='width:100%; height:100%;'>"
+                + "<tr><td style='width:100%; height:100%; text-align:center; vertical-align:middle;'>"
+                + "<div style='display:inline-block;'>"
+                + "<h1>Order Finished</h1>"
+                + "<h3>Hey " + order.getUser().getFullName() + "!</h3>"
+                + "<h4>Your order of the day " + order.getDate() + " has been finished.</h4>"
+                + "<p>If you want to see the details, please go to the link below:</p>"
+                + "<a href=\"" + orderDetailUrl + "\">Order detail</a>"
+                + "<p>Regards, megastore support team.</p>"
+                + "</div></td></tr></table>";
     }
 
 }

--- a/src/test/java/com/_up/megastore/integrations/implementations/OrderControllerTest.java
+++ b/src/test/java/com/_up/megastore/integrations/implementations/OrderControllerTest.java
@@ -81,7 +81,7 @@ class OrderControllerTest extends BaseIntegrationTest {
 
         String response = mockMvc.perform(
                         post("/api/v1/orders/95803676-823b-4454-9844-904d617f42e7/finish")
-                ).andExpect(status().isCreated())
+                ).andExpect(status().isOk())
                 .andReturn()
                 .getResponse()
                 .getContentAsString();
@@ -103,7 +103,7 @@ class OrderControllerTest extends BaseIntegrationTest {
                 .getResponse()
                 .getContentAsString();
 
-        assertContains(response, "message", "Order with id e4990fed-48f6-40ab-b7a8-de242a57ab41 is not in progress.");
+        assertContains(response, "message", "Order is not in progress.");
     }
 
 }

--- a/src/test/java/com/_up/megastore/integrations/implementations/OrderControllerTest.java
+++ b/src/test/java/com/_up/megastore/integrations/implementations/OrderControllerTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class OrderControllerTest extends BaseIntegrationTest {
@@ -47,6 +48,7 @@ class OrderControllerTest extends BaseIntegrationTest {
                                 .content(toJson(request))
                 ).andDo(print())
                 .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.total").value(80000.0))
                 .andReturn()
                 .getResponse()
                 .getContentAsString();

--- a/src/test/resources/scripts/orders/finish_order.sql
+++ b/src/test/resources/scripts/orders/finish_order.sql
@@ -1,0 +1,30 @@
+INSERT INTO sizes (size_id, name, description, deleted)
+VALUES ('03f667f7-4075-41f1-a35d-b4dc71f05b8a', 'Size name', 'Size description', FALSE);
+
+INSERT INTO categories (category_id, name, description, super_category_category_id, deleted)
+VALUES ('0bbad5ac-3986-4832-8a87-0141a83052ce', 'Category name', 'Category description', null, false);
+
+INSERT INTO product_images (url, name)
+VALUES ('url 1', 'image 1'),
+       ('url 2', 'image 2'),
+       ('url 3', 'image 3');
+
+INSERT INTO products (product_id, name, description, price, stock, color, size_size_id, category_category_id, deleted)
+VALUES ('183f205a-3430-4e11-8bca-57672a0ce3ff', 'Product name', 'Product description', 10000.0, 10, '#ffffff', '03f667f7-4075-41f1-a35d-b4dc71f05b8a', '0bbad5ac-3986-4832-8a87-0141a83052ce', false);
+
+INSERT INTO products (product_id, name, description, price, stock, color, size_size_id, category_category_id, deleted)
+VALUES ('22ede130-726f-49ac-9564-d783fc22a6fa', 'Variant name', 'Variant description', 10000.0, 10, '#ffffff', '03f667f7-4075-41f1-a35d-b4dc71f05b8a', '0bbad5ac-3986-4832-8a87-0141a83052ce', false);
+
+INSERT INTO products_images (products_product_id, images_url)
+VALUES ('183f205a-3430-4e11-8bca-57672a0ce3ff', 'url 1'),
+       ('183f205a-3430-4e11-8bca-57672a0ce3ff', 'url 2'),
+       ('22ede130-726f-49ac-9564-d783fc22a6fa', 'url 3');
+
+INSERT INTO users (user_id, username, password, full_name, activated, deleted)
+VALUES ('58fae25b-ea38-4e7b-ab2d-9f555a67836b', 'user test', 'password', 'Client Name', true, false);
+
+INSERT INTO orders (order_id, deleted, state, user_user_id)
+VALUES ('95803676-823b-4454-9844-904d617f42e7', false, 'IN_PROGRESS', '58fae25b-ea38-4e7b-ab2d-9f555a67836b');
+
+INSERT INTO orders (order_id, deleted, state, user_user_id)
+VALUES ('e4990fed-48f6-40ab-b7a8-de242a57ab41', false, 'IN_DELIVERY', '58fae25b-ea38-4e7b-ab2d-9f555a67836b');

--- a/src/test/resources/scripts/orders/finish_order.sql
+++ b/src/test/resources/scripts/orders/finish_order.sql
@@ -20,8 +20,8 @@ VALUES ('183f205a-3430-4e11-8bca-57672a0ce3ff', 'url 1'),
        ('183f205a-3430-4e11-8bca-57672a0ce3ff', 'url 2'),
        ('22ede130-726f-49ac-9564-d783fc22a6fa', 'url 3');
 
-INSERT INTO users (user_id, username, password, full_name, activated, deleted)
-VALUES ('58fae25b-ea38-4e7b-ab2d-9f555a67836b', 'user test', 'password', 'Client Name', true, false);
+INSERT INTO users (user_id, username, password, full_name, email, activated, deleted)
+VALUES ('58fae25b-ea38-4e7b-ab2d-9f555a67836b', 'user test', 'password', 'Client Name', 'client@mail.com', true, false);
 
 INSERT INTO orders (order_id, deleted, state, user_user_id)
 VALUES ('95803676-823b-4454-9844-904d617f42e7', false, 'IN_PROGRESS', '58fae25b-ea38-4e7b-ab2d-9f555a67836b');


### PR DESCRIPTION
Se implementó la funcionalidad para cambiar una orden de estado 'en progreso' a 'finalizada'. Acorde a nuestra seguridad, el endpoint está autorizado únicamente para **administradores**. Además, se realizó un poco de refactoreo en el OrderService y en el OrderMapper para hacer menos rígida la OrderResponse. 

Una vez las órdenes son actualizadas, se le envía un correo electrónico al cliente avisándole de este cambio de estado y pasándole también el link para que pueda consultar su pedido (si la URL del front no es correcta, esto se cambia).

## Tests

Para los tests, se hicieron, nuevamente, dos test de integración acorde a la documentación en Notion sobre los test de transición de estados. Se testea que una orden en estado IN_PROGRESS pase a FINISHED, y posteriormente se testea que una orden que no esté en estado IN_PROGRESS no pueda pasar a FINISHED.

El envío de correos, obviamente, fue mockeado.
