### PR TITLE
feat: deliver order

### DIFF
--- a/src/main/java/com/_up/megastore/controllers/implementations/OrderController.java
+++ b/src/main/java/com/_up/megastore/controllers/implementations/OrderController.java
@@ -27,4 +27,9 @@ public class OrderController implements IOrderController {
         return orderService.finishOrder(orderId);
     }
 
+    @Override
+    public OrderResponse markOrderInDelivery(UUID orderId) {
+        return orderService.markOrderInDelivery(orderId);
+    }
+
 }

--- a/src/main/java/com/_up/megastore/controllers/implementations/OrderController.java
+++ b/src/main/java/com/_up/megastore/controllers/implementations/OrderController.java
@@ -32,4 +32,8 @@ public class OrderController implements IOrderController {
         return orderService.markOrderInDelivery(orderId);
     }
 
+    @Override
+    public OrderResponse deliverOrder(UUID orderId) {
+        return orderService.deliverOrder(orderId);
+    }
 }

--- a/src/main/java/com/_up/megastore/controllers/interfaces/IOrderController.java
+++ b/src/main/java/com/_up/megastore/controllers/interfaces/IOrderController.java
@@ -22,4 +22,8 @@ public interface IOrderController {
     @ResponseStatus(HttpStatus.OK)
     OrderResponse finishOrder(@PathVariable UUID orderId);
 
+    @PostMapping("/{orderId}/mark-in-delivery")
+    @ResponseStatus(HttpStatus.OK)
+    OrderResponse markOrderInDelivery(@PathVariable UUID orderId);
+
 }

--- a/src/main/java/com/_up/megastore/controllers/interfaces/IOrderController.java
+++ b/src/main/java/com/_up/megastore/controllers/interfaces/IOrderController.java
@@ -26,4 +26,8 @@ public interface IOrderController {
     @ResponseStatus(HttpStatus.OK)
     OrderResponse markOrderInDelivery(@PathVariable UUID orderId);
 
+    @PostMapping("/{orderId}/deliver")
+    @ResponseStatus(HttpStatus.OK)
+    OrderResponse deliverOrder(@PathVariable UUID orderId);
+
 }

--- a/src/main/java/com/_up/megastore/data/enums/State.java
+++ b/src/main/java/com/_up/megastore/data/enums/State.java
@@ -5,5 +5,5 @@ public enum State {
     FINISHED,
     IN_DELIVERY,
     DELIVERED,
-    CANCELED
+    CANCELLED
 }

--- a/src/main/java/com/_up/megastore/data/enums/State.java
+++ b/src/main/java/com/_up/megastore/data/enums/State.java
@@ -1,9 +1,23 @@
 package com._up.megastore.data.enums;
 
+import java.util.Collections;
+import java.util.List;
+
 public enum State {
-    IN_PROGRESS,
-    FINISHED,
-    IN_DELIVERY,
-    DELIVERED,
-    CANCELLED
+
+    IN_PROGRESS(Collections.emptyList(), " has been created.", ""),
+    FINISHED(List.of(IN_PROGRESS), " has been finished.", "Order is not in progress."),
+    IN_DELIVERY(List.of(FINISHED), " is now in delivery.", "Order is not finished."),
+    DELIVERED(List.of(IN_DELIVERY), " has been delivered.", "Order is not in delivery."),
+    CANCELLED(List.of(IN_PROGRESS, FINISHED), " has been cancelled.", "Order is not in progress or finished.");
+
+    public final List<State> previousStates;
+    public final String stateMessage;
+    public final String exceptionMessage;
+
+    State(List<State> previousStates, String stateMessage, String exceptionMessage) {
+        this.previousStates = previousStates;
+        this.stateMessage = stateMessage;
+        this.exceptionMessage = exceptionMessage;
+    }
 }

--- a/src/main/java/com/_up/megastore/security/filter/JWTAuthenticationFilter.java
+++ b/src/main/java/com/_up/megastore/security/filter/JWTAuthenticationFilter.java
@@ -72,13 +72,8 @@ public class JWTAuthenticationFilter extends OncePerRequestFilter {
     protected boolean shouldNotFilter(HttpServletRequest request) {
         AntPathMatcher pathMatcher = new AntPathMatcher();
 
-        boolean isWhiteListed = Arrays.stream(Endpoints.WHITE_LISTED_URLS)
+        return Arrays.stream(Endpoints.WHITE_LISTED_URLS)
                 .anyMatch(url -> pathMatcher.match(url, request.getRequestURI()));
-
-        boolean isAllowedForGet = Arrays.stream(Endpoints.ALLOWED_TO_GET_BY_USERS_URLS)
-                .anyMatch(url -> pathMatcher.match(url, request.getRequestURI()) && "GET".equals(request.getMethod()));
-
-        return isWhiteListed || isAllowedForGet;
     }
 
     private String extractTokenFromRequest(HttpServletRequest request) {

--- a/src/main/java/com/_up/megastore/services/interfaces/IOrderService.java
+++ b/src/main/java/com/_up/megastore/services/interfaces/IOrderService.java
@@ -13,4 +13,6 @@ public interface IOrderService {
     Order findOrderByIdOrThrowException(UUID orderId);
 
     OrderResponse finishOrder(UUID orderId);
+
+    OrderResponse markOrderInDelivery(UUID orderId);
 }

--- a/src/main/java/com/_up/megastore/services/interfaces/IOrderService.java
+++ b/src/main/java/com/_up/megastore/services/interfaces/IOrderService.java
@@ -15,4 +15,6 @@ public interface IOrderService {
     OrderResponse finishOrder(UUID orderId);
 
     OrderResponse markOrderInDelivery(UUID orderId);
+
+    OrderResponse deliverOrder(UUID orderId);
 }

--- a/src/main/java/com/_up/megastore/utils/EmailBuilder.java
+++ b/src/main/java/com/_up/megastore/utils/EmailBuilder.java
@@ -1,10 +1,12 @@
 package com._up.megastore.utils;
 
+import com._up.megastore.data.enums.State;
 import com._up.megastore.data.model.Order;
 import com._up.megastore.data.model.User;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
 import java.util.UUID;
 
 @Component
@@ -12,6 +14,13 @@ public class EmailBuilder {
 
     @Value("${frontend.url}")
     private String frontendURL;
+
+    private final Map<State, String> STATE_MESSAGES = Map.of(
+            State.IN_PROGRESS, " has been created.",
+            State.FINISHED, " has been finished.",
+            State.IN_DELIVERY, " is now in delivery.",
+            State.DELIVERED, " has been delivered."
+    );
 
     public String buildActivationEmailBody(User user, UUID activationToken) {
         String activationUrl = frontendURL + "/auth/activate?userId="
@@ -114,30 +123,15 @@ public class EmailBuilder {
                 + "</table>";
     }
 
-    public String buildFinishOrderEmail(Order order) {
+    public String buildOrderEmail(Order order, String subject) {
         String orderDetailUrl = frontendURL + "/orders/" + order.getOrderId();
 
         return "<table style='width:100%; height:100%;'>"
                 + "<tr><td style='width:100%; height:100%; text-align:center; vertical-align:middle;'>"
                 + "<div style='display:inline-block;'>"
-                + "<h1>Order Finished</h1>"
+                + "<h1>" + subject + "</h1>"
                 + "<h3>Hey " + order.getUser().getFullName() + "!</h3>"
-                + "<h4>Your order of the day " + order.getDate() + " has been finished.</h4>"
-                + "<p>If you want to see the details, please go to the link below:</p>"
-                + "<a href=\"" + orderDetailUrl + "\">Order detail</a>"
-                + "<p>Regards, megastore support team.</p>"
-                + "</div></td></tr></table>";
-    }
-
-    public String buildMarkOrderInDeliveryEmail(Order order) {
-        String orderDetailUrl = frontendURL + "/orders/" + order.getOrderId();
-
-        return "<table style='width:100%; height:100%;'>"
-                + "<tr><td style='width:100%; height:100%; text-align:center; vertical-align:middle;'>"
-                + "<div style='display:inline-block;'>"
-                + "<h1>Order Finished</h1>"
-                + "<h3>Hey " + order.getUser().getFullName() + "!</h3>"
-                + "<h4>Your order of the day " + order.getDate() + " is in delivery.</h4>"
+                + "<h4>Your order of the day " + order.getDate() + STATE_MESSAGES.get(order.getState()) + "</h4>"
                 + "<p>If you want to see the details, please go to the link below:</p>"
                 + "<a href=\"" + orderDetailUrl + "\">Order detail</a>"
                 + "<p>Regards, megastore support team.</p>"

--- a/src/main/java/com/_up/megastore/utils/EmailBuilder.java
+++ b/src/main/java/com/_up/megastore/utils/EmailBuilder.java
@@ -129,4 +129,18 @@ public class EmailBuilder {
                 + "</div></td></tr></table>";
     }
 
+    public String buildMarkOrderInDeliveryEmail(Order order) {
+        String orderDetailUrl = frontendURL + "/orders/" + order.getOrderId();
+
+        return "<table style='width:100%; height:100%;'>"
+                + "<tr><td style='width:100%; height:100%; text-align:center; vertical-align:middle;'>"
+                + "<div style='display:inline-block;'>"
+                + "<h1>Order Finished</h1>"
+                + "<h3>Hey " + order.getUser().getFullName() + "!</h3>"
+                + "<h4>Your order of the day " + order.getDate() + " is in delivery.</h4>"
+                + "<p>If you want to see the details, please go to the link below:</p>"
+                + "<a href=\"" + orderDetailUrl + "\">Order detail</a>"
+                + "<p>Regards, megastore support team.</p>"
+                + "</div></td></tr></table>";
+    }
 }

--- a/src/main/java/com/_up/megastore/utils/EmailBuilder.java
+++ b/src/main/java/com/_up/megastore/utils/EmailBuilder.java
@@ -1,12 +1,10 @@
 package com._up.megastore.utils;
 
-import com._up.megastore.data.enums.State;
 import com._up.megastore.data.model.Order;
 import com._up.megastore.data.model.User;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import java.util.Map;
 import java.util.UUID;
 
 @Component
@@ -14,13 +12,6 @@ public class EmailBuilder {
 
     @Value("${frontend.url}")
     private String frontendURL;
-
-    private final Map<State, String> STATE_MESSAGES = Map.of(
-            State.IN_PROGRESS, " has been created.",
-            State.FINISHED, " has been finished.",
-            State.IN_DELIVERY, " is now in delivery.",
-            State.DELIVERED, " has been delivered."
-    );
 
     public String buildActivationEmailBody(User user, UUID activationToken) {
         String activationUrl = frontendURL + "/auth/activate?userId="
@@ -131,7 +122,7 @@ public class EmailBuilder {
                 + "<div style='display:inline-block;'>"
                 + "<h1>" + subject + "</h1>"
                 + "<h3>Hey " + order.getUser().getFullName() + "!</h3>"
-                + "<h4>Your order of the day " + order.getDate() + STATE_MESSAGES.get(order.getState()) + "</h4>"
+                + "<h4>Your order of the day " + order.getDate() + order.getState().stateMessage + "</h4>"
                 + "<p>If you want to see the details, please go to the link below:</p>"
                 + "<a href=\"" + orderDetailUrl + "\">Order detail</a>"
                 + "<p>Regards, megastore support team.</p>"

--- a/src/test/java/com/_up/megastore/integrations/implementations/OrderControllerTest.java
+++ b/src/test/java/com/_up/megastore/integrations/implementations/OrderControllerTest.java
@@ -131,4 +131,32 @@ class OrderControllerTest extends BaseIntegrationTest {
         assertContains(response, "message", "Order is not finished.");
     }
 
+    @Test
+    @Sql("/scripts/orders/deliver_order.sql")
+    void deliverOrder() throws Exception {
+        String response = mockMvc.perform(
+                        post("/api/v1/orders/95803676-823b-4454-9844-904d617f42e2/deliver")
+                ).andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        assertContains(response, "state", "DELIVERED");
+
+        verify(emailService, times(1)).sendEmail(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @Sql("/scripts/orders/deliver_order.sql")
+    void deliverOrderWithIncompatibleState() throws Exception {
+        String response = mockMvc.perform(
+                        post("/api/v1/orders/e4990fed-48f6-40ab-b7a8-de242a57ab40/deliver")
+                ).andExpect(status().isBadRequest())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        assertContains(response, "message", "Order is not in delivery.");
+    }
+
 }

--- a/src/test/java/com/_up/megastore/services/implementations/OrderServiceTest.java
+++ b/src/test/java/com/_up/megastore/services/implementations/OrderServiceTest.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -68,19 +69,31 @@ class OrderServiceTest {
         @Test
         void finishOrder_orderIsInProgress() {
             order.setState(State.IN_PROGRESS);
-            assertDoesNotThrow(() -> orderService.finishOrder(orderId));
+
+            assertDoesNotThrow(() -> {
+                final var orderResponse = orderService.finishOrder(orderId);
+                assertEquals(orderResponse.state(), State.FINISHED.name());
+            });
         }
 
         @Test
         void markOrderInDelivery_orderIsFinished() {
             order.setState(State.FINISHED);
-            assertDoesNotThrow(() -> orderService.markOrderInDelivery(orderId));
+
+            assertDoesNotThrow(() -> {
+                final var orderResponse = orderService.markOrderInDelivery(orderId);
+                assertEquals(orderResponse.state(), State.IN_DELIVERY.name());
+            });
         }
 
         @Test
         void deliverOrder_orderIsInDelivery() {
             order.setState(State.IN_DELIVERY);
-            assertDoesNotThrow(() -> orderService.deliverOrder(orderId));
+
+            assertDoesNotThrow(() -> {
+                final var orderResponse = orderService.deliverOrder(orderId);
+                assertEquals(orderResponse.state(), State.DELIVERED.name());
+            });
         }
     }
 

--- a/src/test/java/com/_up/megastore/services/implementations/OrderServiceTest.java
+++ b/src/test/java/com/_up/megastore/services/implementations/OrderServiceTest.java
@@ -1,0 +1,162 @@
+package com._up.megastore.services.implementations;
+
+import com._up.megastore.data.enums.State;
+import com._up.megastore.data.model.Order;
+import com._up.megastore.data.model.User;
+import com._up.megastore.data.repositories.IOrderRepository;
+import com._up.megastore.utils.EmailBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+
+@ExtendWith(MockitoExtension.class)
+class OrderServiceTest {
+
+    @Mock
+    private IOrderRepository orderRepository;
+
+    @Mock
+    private EmailBuilder emailBuilder;
+
+    @Mock
+    private EmailService emailService;
+
+    @InjectMocks
+    private OrderService orderService;
+
+    private final UUID orderId = UUID.randomUUID();
+    private final Order order = spy(Order.class);
+    private final User user = mock(User.class);
+
+    @BeforeEach
+    void setUp() {
+        when(orderRepository.findById(any(UUID.class))).thenReturn(Optional.of(order));
+    }
+
+    @Nested
+    class WhenStatesAreCompatible {
+
+        @BeforeEach
+        void setUp() {
+            when(orderRepository.save(any(Order.class))).thenReturn(order);
+            when(orderRepository.getOrderTotal(any(Order.class))).thenReturn(1000.0);
+            when(order.getUser()).thenReturn(user);
+            when(user.getEmail()).thenReturn("User email");
+            when(emailBuilder.buildOrderEmail(any(Order.class), anyString())).thenReturn("Email content");
+
+            doNothing().when(emailService).sendEmail(anyString(), anyString(), anyString());
+        }
+
+        @Test
+        void finishOrder_orderIsInProgress() {
+            order.setState(State.IN_PROGRESS);
+            assertDoesNotThrow(() -> orderService.finishOrder(orderId));
+        }
+
+        @Test
+        void markOrderInDelivery_orderIsFinished() {
+            order.setState(State.FINISHED);
+            assertDoesNotThrow(() -> orderService.markOrderInDelivery(orderId));
+        }
+
+        @Test
+        void deliverOrder_orderIsInDelivery() {
+            order.setState(State.IN_DELIVERY);
+            assertDoesNotThrow(() -> orderService.deliverOrder(orderId));
+        }
+    }
+
+    @Nested
+    class WhenStatesAreIncompatible {
+
+        @Test
+        void finishOrder_orderIsFinished() {
+            order.setState(State.FINISHED);
+            assertThrows(ResponseStatusException.class, () -> orderService.finishOrder(orderId));
+        }
+
+        @Test
+        void finishOrder_orderIsInDelivery() {
+            order.setState(State.IN_DELIVERY);
+            assertThrows(ResponseStatusException.class, () -> orderService.finishOrder(orderId));
+        }
+
+        @Test
+        void finishOrder_orderIsDelivered() {
+            order.setState(State.DELIVERED);
+            assertThrows(ResponseStatusException.class, () -> orderService.finishOrder(orderId));
+        }
+
+        @Test
+        void finishOrder_orderIsCancelled() {
+            order.setState(State.CANCELLED);
+            assertThrows(ResponseStatusException.class, () -> orderService.finishOrder(orderId));
+        }
+
+        @Test
+        void markOrderInDelivery_orderIsInProgress() {
+            order.setState(State.IN_PROGRESS);
+            assertThrows(ResponseStatusException.class, () -> orderService.markOrderInDelivery(orderId));
+        }
+
+        @Test
+        void markOrderInDelivery_orderIsInDelivery() {
+            order.setState(State.IN_DELIVERY);
+            assertThrows(ResponseStatusException.class, () -> orderService.markOrderInDelivery(orderId));
+        }
+
+        @Test
+        void markOrderInDelivery_orderIsDelivered() {
+            order.setState(State.DELIVERED);
+            assertThrows(ResponseStatusException.class, () -> orderService.markOrderInDelivery(orderId));
+        }
+
+        @Test
+        void markOrderInDelivery_orderIsCancelled() {
+            order.setState(State.CANCELLED);
+            assertThrows(ResponseStatusException.class, () -> orderService.markOrderInDelivery(orderId));
+        }
+
+        @Test
+        void deliverOrder_orderIsInProgress() {
+            order.setState(State.IN_PROGRESS);
+            assertThrows(ResponseStatusException.class, () -> orderService.deliverOrder(orderId));
+        }
+
+        @Test
+        void deliverOrder_orderIsFinished() {
+            order.setState(State.FINISHED);
+            assertThrows(ResponseStatusException.class, () -> orderService.deliverOrder(orderId));
+        }
+
+        @Test
+        void deliverOrder_orderIsDelivered() {
+            order.setState(State.DELIVERED);
+            assertThrows(ResponseStatusException.class, () -> orderService.deliverOrder(orderId));
+        }
+
+        @Test
+        void deliverOrder_orderIsCancelled() {
+            order.setState(State.CANCELLED);
+            assertThrows(ResponseStatusException.class, () -> orderService.deliverOrder(orderId));
+        }
+    }
+}

--- a/src/test/resources/scripts/orders/deliver_order.sql
+++ b/src/test/resources/scripts/orders/deliver_order.sql
@@ -1,0 +1,30 @@
+INSERT INTO sizes (size_id, name, description, deleted)
+VALUES ('03f667f7-4075-41f1-a35d-b4dc71f05b8a', 'Size name', 'Size description', FALSE);
+
+INSERT INTO categories (category_id, name, description, super_category_category_id, deleted)
+VALUES ('0bbad5ac-3986-4832-8a87-0141a83052ce', 'Category name', 'Category description', null, false);
+
+INSERT INTO product_images (url, name)
+VALUES ('url 1', 'image 1'),
+       ('url 2', 'image 2'),
+       ('url 3', 'image 3');
+
+INSERT INTO products (product_id, name, description, price, stock, color, size_size_id, category_category_id, deleted)
+VALUES ('183f205a-3430-4e11-8bca-57672a0ce3ff', 'Product name', 'Product description', 10000.0, 10, '#ffffff', '03f667f7-4075-41f1-a35d-b4dc71f05b8a', '0bbad5ac-3986-4832-8a87-0141a83052ce', false);
+
+INSERT INTO products (product_id, name, description, price, stock, color, size_size_id, category_category_id, deleted)
+VALUES ('22ede130-726f-49ac-9564-d783fc22a6fa', 'Variant name', 'Variant description', 10000.0, 10, '#ffffff', '03f667f7-4075-41f1-a35d-b4dc71f05b8a', '0bbad5ac-3986-4832-8a87-0141a83052ce', false);
+
+INSERT INTO products_images (products_product_id, images_url)
+VALUES ('183f205a-3430-4e11-8bca-57672a0ce3ff', 'url 1'),
+       ('183f205a-3430-4e11-8bca-57672a0ce3ff', 'url 2'),
+       ('22ede130-726f-49ac-9564-d783fc22a6fa', 'url 3');
+
+INSERT INTO users (user_id, username, password, full_name, email, activated, deleted)
+VALUES ('58fae25b-ea38-4e7b-ab2d-9f555a67836b', 'user test', 'password', 'Client Name', 'client@mail.com', true, false);
+
+INSERT INTO orders (order_id, deleted, state, user_user_id)
+VALUES ('95803676-823b-4454-9844-904d617f42e2', false, 'IN_DELIVERY', '58fae25b-ea38-4e7b-ab2d-9f555a67836b');
+
+INSERT INTO orders (order_id, deleted, state, user_user_id)
+VALUES ('e4990fed-48f6-40ab-b7a8-de242a57ab40', false, 'DELIVERED', '58fae25b-ea38-4e7b-ab2d-9f555a67836b');

--- a/src/test/resources/scripts/orders/mark_order_in_delivery.sql
+++ b/src/test/resources/scripts/orders/mark_order_in_delivery.sql
@@ -1,0 +1,30 @@
+INSERT INTO sizes (size_id, name, description, deleted)
+VALUES ('03f667f7-4075-41f1-a35d-b4dc71f05b8a', 'Size name', 'Size description', FALSE);
+
+INSERT INTO categories (category_id, name, description, super_category_category_id, deleted)
+VALUES ('0bbad5ac-3986-4832-8a87-0141a83052ce', 'Category name', 'Category description', null, false);
+
+INSERT INTO product_images (url, name)
+VALUES ('url 1', 'image 1'),
+       ('url 2', 'image 2'),
+       ('url 3', 'image 3');
+
+INSERT INTO products (product_id, name, description, price, stock, color, size_size_id, category_category_id, deleted)
+VALUES ('183f205a-3430-4e11-8bca-57672a0ce3ff', 'Product name', 'Product description', 10000.0, 10, '#ffffff', '03f667f7-4075-41f1-a35d-b4dc71f05b8a', '0bbad5ac-3986-4832-8a87-0141a83052ce', false);
+
+INSERT INTO products (product_id, name, description, price, stock, color, size_size_id, category_category_id, deleted)
+VALUES ('22ede130-726f-49ac-9564-d783fc22a6fa', 'Variant name', 'Variant description', 10000.0, 10, '#ffffff', '03f667f7-4075-41f1-a35d-b4dc71f05b8a', '0bbad5ac-3986-4832-8a87-0141a83052ce', false);
+
+INSERT INTO products_images (products_product_id, images_url)
+VALUES ('183f205a-3430-4e11-8bca-57672a0ce3ff', 'url 1'),
+       ('183f205a-3430-4e11-8bca-57672a0ce3ff', 'url 2'),
+       ('22ede130-726f-49ac-9564-d783fc22a6fa', 'url 3');
+
+INSERT INTO users (user_id, username, password, full_name, email, activated, deleted)
+VALUES ('58fae25b-ea38-4e7b-ab2d-9f555a67836b', 'user test', 'password', 'Client Name', 'client@mail.com', true, false);
+
+INSERT INTO orders (order_id, deleted, state, user_user_id)
+VALUES ('95803676-823b-4454-9844-904d617f42e2', false, 'FINISHED', '58fae25b-ea38-4e7b-ab2d-9f555a67836b');
+
+INSERT INTO orders (order_id, deleted, state, user_user_id)
+VALUES ('e4990fed-48f6-40ab-b7a8-de242a57ab40', false, 'IN_DELIVERY', '58fae25b-ea38-4e7b-ab2d-9f555a67836b');


### PR DESCRIPTION
Se implementó la funcionalidad para **marcar un pedido como 'en entrega'** y para **entregarlo**. Decidí unir estas funcionalidades para no hacer tantas MR. Además de ello, se refactorizó la construcción de correos electrónicos para enviar los estados de las órdenes, y se agregó también el funcionamiento para enviar correos que confirmen la creación de los pedidos.

## Tests

Esto es lo más importante. Al igual que en #99, se hicieron dos tests unitarios para cada mini-feature (marcar como en entrega y entregar), uno con un escenario exitoso y otro con un escenario inválido.

Además de ello, también se implementaron los **tests unitarios de transición de estados**, documentados en Notion. Estos tests unitarios aplican al OrderService, particularmente a cada uno de los métodos para pasar de un estado a otro (finishOrder, markOrderInDelivery, deliverOrder). Cada test es un escenario de los casos de prueba documentados.