### PR TITLE
feat: cancel order

### DIFF
--- a/src/main/java/com/_up/megastore/config/AuthConfig.java
+++ b/src/main/java/com/_up/megastore/config/AuthConfig.java
@@ -13,6 +13,8 @@ import org.springframework.security.config.annotation.authentication.configurati
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.PathMatcher;
 
 @Configuration
 public class AuthConfig {
@@ -49,5 +51,10 @@ public class AuthConfig {
     mapper.configure(DeserializationFeature.ACCEPT_FLOAT_AS_INT, false);
     mapper.registerModule(new JavaTimeModule());
     return mapper;
+  }
+
+  @Bean
+  public PathMatcher pathMatcher() {
+    return new AntPathMatcher();
   }
 }

--- a/src/main/java/com/_up/megastore/config/SecurityConfig.java
+++ b/src/main/java/com/_up/megastore/config/SecurityConfig.java
@@ -14,10 +14,18 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 
-import static com._up.megastore.security.utils.Endpoints.ALLOWED_TO_ADMINISTRATORS_URLS;
-import static com._up.megastore.security.utils.Endpoints.ALLOWED_TO_GET_BY_USERS_URLS;
-import static com._up.megastore.security.utils.Endpoints.ALLOWED_TO_POST_BY_USERS_URLS;
-import static com._up.megastore.security.utils.Endpoints.WHITE_LISTED_URLS;
+import static com._up.megastore.security.utils.Endpoints.ADMIN_ORDER_MODIFICATON_ENDPOINTS;
+import static com._up.megastore.security.utils.Endpoints.ANY_USER_ENDPOINTS;
+import static com._up.megastore.security.utils.Endpoints.AUTH_ENDPOINTS;
+import static com._up.megastore.security.utils.Endpoints.DELETED_ENTITIES_ENDPOINTS;
+import static com._up.megastore.security.utils.Endpoints.DELETE_INFORMATION_ENDPOINTS;
+import static com._up.megastore.security.utils.Endpoints.ERROR_ENDPOINTS;
+import static com._up.megastore.security.utils.Endpoints.GET_ALL_ORDERS;
+import static com._up.megastore.security.utils.Endpoints.GET_ONE_ORDER;
+import static com._up.megastore.security.utils.Endpoints.PUBLIC_INFORMATION_ENDPOINTS;
+import static com._up.megastore.security.utils.Endpoints.SAVE_INFORMATION_ENDPOINTS;
+import static com._up.megastore.security.utils.Endpoints.UPDATE_INFORMATION_ENDPOINTS;
+import static com._up.megastore.security.utils.Endpoints.USER_ORDER_MODIFICATION_ENDPOINTS;
 
 @Configuration
 @EnableWebSecurity
@@ -42,11 +50,19 @@ public class SecurityConfig {
     httpSecurity
         .csrf(AbstractHttpConfigurer::disable)
         .authorizeHttpRequests(authRequest -> authRequest
-            .requestMatchers(WHITE_LISTED_URLS).permitAll()
             .requestMatchers(HttpMethod.OPTIONS).permitAll()
-            .requestMatchers(HttpMethod.GET, ALLOWED_TO_GET_BY_USERS_URLS).permitAll()
-            .requestMatchers(HttpMethod.POST, ALLOWED_TO_POST_BY_USERS_URLS).hasRole(Role.USER.name())
-            .requestMatchers(ALLOWED_TO_ADMINISTRATORS_URLS).hasRole(Role.ADMIN.name()))
+            .requestMatchers(AUTH_ENDPOINTS, ERROR_ENDPOINTS).permitAll()
+            .requestMatchers(HttpMethod.POST, ANY_USER_ENDPOINTS).permitAll()
+            .requestMatchers(HttpMethod.GET, DELETED_ENTITIES_ENDPOINTS).hasRole(Role.ADMIN.name())
+            .requestMatchers(HttpMethod.GET, PUBLIC_INFORMATION_ENDPOINTS).permitAll()
+            .requestMatchers(HttpMethod.POST, SAVE_INFORMATION_ENDPOINTS).hasRole(Role.ADMIN.name())
+            .requestMatchers(HttpMethod.PUT, UPDATE_INFORMATION_ENDPOINTS).hasRole(Role.ADMIN.name())
+            .requestMatchers(HttpMethod.DELETE, DELETE_INFORMATION_ENDPOINTS).hasRole(Role.ADMIN.name())
+            .requestMatchers(HttpMethod.POST, USER_ORDER_MODIFICATION_ENDPOINTS).hasAnyRole(Role.USER.name(), Role.ADMIN.name())
+            .requestMatchers(HttpMethod.POST, ADMIN_ORDER_MODIFICATON_ENDPOINTS).hasRole(Role.ADMIN.name())
+            .requestMatchers(HttpMethod.GET, GET_ALL_ORDERS).hasRole(Role.ADMIN.name())
+            .requestMatchers(HttpMethod.GET, GET_ONE_ORDER).hasAnyRole(Role.ADMIN.name(), Role.USER.name())
+            .anyRequest().denyAll())
         .sessionManagement(sessionManager -> sessionManager.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .httpBasic(httpSecurityHttpBasicConfigurer -> httpSecurityHttpBasicConfigurer
                 .authenticationEntryPoint(globalAuthenticationEntryPoint))

--- a/src/main/java/com/_up/megastore/controllers/implementations/OrderController.java
+++ b/src/main/java/com/_up/megastore/controllers/implementations/OrderController.java
@@ -36,4 +36,9 @@ public class OrderController implements IOrderController {
     public OrderResponse deliverOrder(UUID orderId) {
         return orderService.deliverOrder(orderId);
     }
+
+    @Override
+    public OrderResponse cancelOrder(UUID orderId) {
+        return orderService.cancelOrder(orderId);
+    }
 }

--- a/src/main/java/com/_up/megastore/controllers/implementations/OrderController.java
+++ b/src/main/java/com/_up/megastore/controllers/implementations/OrderController.java
@@ -1,6 +1,7 @@
 package com._up.megastore.controllers.implementations;
 
 import com._up.megastore.controllers.interfaces.IOrderController;
+import com._up.megastore.controllers.requests.CancelOrderRequest;
 import com._up.megastore.controllers.requests.CreateOrderRequest;
 import com._up.megastore.controllers.responses.OrderResponse;
 import com._up.megastore.services.interfaces.IOrderService;
@@ -38,7 +39,7 @@ public class OrderController implements IOrderController {
     }
 
     @Override
-    public OrderResponse cancelOrder(UUID orderId) {
-        return orderService.cancelOrder(orderId);
+    public OrderResponse cancelOrder(UUID orderId, CancelOrderRequest cancelOrderRequest) {
+        return orderService.cancelOrder(orderId, cancelOrderRequest);
     }
 }

--- a/src/main/java/com/_up/megastore/controllers/interfaces/IOrderController.java
+++ b/src/main/java/com/_up/megastore/controllers/interfaces/IOrderController.java
@@ -30,4 +30,8 @@ public interface IOrderController {
     @ResponseStatus(HttpStatus.OK)
     OrderResponse deliverOrder(@PathVariable UUID orderId);
 
+    @PostMapping("/{orderId}/cancel")
+    @ResponseStatus(HttpStatus.OK)
+    OrderResponse cancelOrder(@PathVariable UUID orderId);
+
 }

--- a/src/main/java/com/_up/megastore/controllers/interfaces/IOrderController.java
+++ b/src/main/java/com/_up/megastore/controllers/interfaces/IOrderController.java
@@ -1,7 +1,9 @@
 package com._up.megastore.controllers.interfaces;
 
+import com._up.megastore.controllers.requests.CancelOrderRequest;
 import com._up.megastore.controllers.requests.CreateOrderRequest;
 import com._up.megastore.controllers.responses.OrderResponse;
+import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -16,7 +18,7 @@ public interface IOrderController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    OrderResponse saveOrder(@RequestBody CreateOrderRequest createOrderRequest);
+    OrderResponse saveOrder(@RequestBody @Valid CreateOrderRequest createOrderRequest);
 
     @PostMapping("/{orderId}/finish")
     @ResponseStatus(HttpStatus.OK)
@@ -32,6 +34,8 @@ public interface IOrderController {
 
     @PostMapping("/{orderId}/cancel")
     @ResponseStatus(HttpStatus.OK)
-    OrderResponse cancelOrder(@PathVariable UUID orderId);
-
+    OrderResponse cancelOrder(
+            @PathVariable UUID orderId,
+            @RequestBody @Valid CancelOrderRequest cancelOrderRequest
+    );
 }

--- a/src/main/java/com/_up/megastore/controllers/requests/CancelOrderRequest.java
+++ b/src/main/java/com/_up/megastore/controllers/requests/CancelOrderRequest.java
@@ -1,0 +1,10 @@
+package com._up.megastore.controllers.requests;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record CancelOrderRequest(
+        @NotNull(message = "Category name must not be null")
+        @Size(min = 5, max = 50, message = "Category name must be between 5 and 50 characters")
+        String reason
+) {}

--- a/src/main/java/com/_up/megastore/controllers/responses/OrderResponse.java
+++ b/src/main/java/com/_up/megastore/controllers/responses/OrderResponse.java
@@ -10,6 +10,7 @@ public record OrderResponse(
         LocalDate date,
         String clientName,
         String state,
+        String reasonToCancel,
         Double total,
         List<OrderDetailResponse> orderDetails
 ) {}

--- a/src/main/java/com/_up/megastore/data/enums/State.java
+++ b/src/main/java/com/_up/megastore/data/enums/State.java
@@ -5,19 +5,55 @@ import java.util.List;
 
 public enum State {
 
-    IN_PROGRESS(Collections.emptyList(), " has been created.", ""),
-    FINISHED(List.of(IN_PROGRESS), " has been finished.", "Order is not in progress."),
-    IN_DELIVERY(List.of(FINISHED), " is now in delivery.", "Order is not finished."),
-    DELIVERED(List.of(IN_DELIVERY), " has been delivered.", "Order is not in delivery."),
-    CANCELLED(List.of(IN_PROGRESS, FINISHED), " has been cancelled.", "Order is not in progress or finished.");
+    IN_PROGRESS(
+            Collections.emptyList(),
+            " has been created.",
+            "",
+            "Order Created"
+    ),
+
+    FINISHED(
+            List.of(IN_PROGRESS),
+            " has been finished.",
+            "Order is not in progress.",
+            "Order Finished"
+    ),
+
+    IN_DELIVERY(
+            List.of(FINISHED),
+            " is now in delivery.",
+            "Order is not finished.",
+            "Order In Delivery"
+    ),
+
+    DELIVERED(
+            List.of(IN_DELIVERY),
+            " has been delivered.",
+            "Order is not in delivery.",
+            "Order Delivered"
+    ),
+
+    CANCELLED(
+            List.of(IN_PROGRESS, FINISHED),
+            " has been cancelled.",
+            "Order is not in progress or finished.",
+            "Order Cancelled"
+    );
 
     public final List<State> previousStates;
     public final String stateMessage;
     public final String exceptionMessage;
+    public final String subject;
 
-    State(List<State> previousStates, String stateMessage, String exceptionMessage) {
+    State(
+            List<State> previousStates,
+            String stateMessage,
+            String exceptionMessage,
+            String subject
+    ) {
         this.previousStates = previousStates;
         this.stateMessage = stateMessage;
         this.exceptionMessage = exceptionMessage;
+        this.subject = subject;
     }
 }

--- a/src/main/java/com/_up/megastore/data/model/Order.java
+++ b/src/main/java/com/_up/megastore/data/model/Order.java
@@ -42,6 +42,8 @@ public class Order {
     @Builder.Default
     private LocalDate date = LocalDate.now();
 
+    private String reasonToCancel = null;
+
     private boolean deleted = false;
 
     @Id

--- a/src/main/java/com/_up/megastore/security/utils/Endpoints.java
+++ b/src/main/java/com/_up/megastore/security/utils/Endpoints.java
@@ -2,27 +2,61 @@ package com._up.megastore.security.utils;
 
 public class Endpoints {
 
-    public static String[] WHITE_LISTED_URLS = {
-            "/auth/**",
-            "/error",
-            "/api/v1/users/*/activate",
-            "/api/v1/users/recover-password/**",
-            "/api/v1/users/resend-activation-email",
-            "/api/v1/users/send-new-activation-token",
+    public static String AUTH_ENDPOINTS = "/auth/**";
+
+    public static String ERROR_ENDPOINTS = "/error/**";
+
+    public static String ANY_USER_ENDPOINTS = "/api/v1/users/**";
+
+    public static String[] DELETED_ENTITIES_ENDPOINTS = {
+            "/api/v1/products/*/deleted",
+            "/api/v1/sizes/*/deleted",
+            "/api/v1/categories/*/deleted",
     };
 
-    public static String[] ALLOWED_TO_GET_BY_USERS_URLS = {
-            "/api/v1/products/**",
-            "/api/v1/categories/**",
-            "/api/v1/sizes/**"
+    public static String[] PUBLIC_INFORMATION_ENDPOINTS = {
+            "/api/v1/products",
+            "/api/v1/products/*",
+            "/api/v1/categories",
+            "/api/v1/categories/*",
+            "/api/v1/sizes",
+            "/api/v1/sizes/*",
     };
 
-    public static String[] ALLOWED_TO_POST_BY_USERS_URLS = {
-            "/api/v1/orders"
+    public static String[] SAVE_INFORMATION_ENDPOINTS = {
+            "/api/v1/products",
+            "/api/v1/products/*/restore",
+            "/api/v1/categories",
+            "/api/v1/categories/*/restore",
+            "/api/v1/sizes",
+            "/api/v1/sizes/*/restore",
     };
 
-    public static String[] ALLOWED_TO_ADMINISTRATORS_URLS = {
-            "/api/v1/**"
+    public static String[] UPDATE_INFORMATION_ENDPOINTS = {
+            "/api/v1/products/*",
+            "/api/v1/categories/*",
+            "/api/v1/sizes/*",
     };
+
+    public static String[] DELETE_INFORMATION_ENDPOINTS = {
+            "/api/v1/products/*",
+            "/api/v1/categories/*",
+            "/api/v1/sizes/*",
+    };
+
+    public static String[] USER_ORDER_MODIFICATION_ENDPOINTS = {
+            "/api/v1/orders",
+            "/api/v1/orders/*/cancel",
+    };
+
+    public static String[] ADMIN_ORDER_MODIFICATON_ENDPOINTS = {
+            "/api/v1/orders/*/finish",
+            "/api/v1/orders/*/mark-in-delivery",
+            "/api/v1/orders/*/delivered",
+    };
+
+    public static String GET_ALL_ORDERS = "/api/v1/orders";
+
+    public static String GET_ONE_ORDER = "/api/v1/orders/*";
 
 }

--- a/src/main/java/com/_up/megastore/services/implementations/OrderService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/OrderService.java
@@ -1,5 +1,6 @@
 package com._up.megastore.services.implementations;
 
+import com._up.megastore.controllers.requests.CancelOrderRequest;
 import com._up.megastore.controllers.requests.CreateOrderRequest;
 import com._up.megastore.controllers.responses.OrderResponse;
 import com._up.megastore.data.enums.State;
@@ -80,14 +81,21 @@ public class OrderService implements IOrderService {
     }
 
     @Override
-    public OrderResponse cancelOrder(UUID orderId) {
-        return changeOrderState(orderId, State.CANCELLED);
+    public OrderResponse cancelOrder(UUID orderId, CancelOrderRequest cancelOrderRequest) {
+        return changeOrderState(orderId, State.CANCELLED, cancelOrderRequest.reason());
     }
 
     private OrderResponse changeOrderState(UUID orderId, State newState) {
+        return changeOrderState(orderId, newState, null);
+    }
+
+    private OrderResponse changeOrderState(UUID orderId, State newState, String reasonToCancel) {
         Order order = findOrderByIdOrThrowException(orderId);
         throwExceptionIfCurrentStateIsIncompatible(order, newState);
         order.setState(newState);
+
+        if (newState == State.CANCELLED)
+            order.setReasonToCancel(reasonToCancel);
 
         sendOrderEmail(order, newState.subject);
 

--- a/src/main/java/com/_up/megastore/services/implementations/OrderService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/OrderService.java
@@ -65,40 +65,31 @@ public class OrderService implements IOrderService {
     }
 
     @Override
-    public OrderResponse finishOrder(UUID id) {
-        Order order = findOrderByIdOrThrowException(id);
-        throwExceptionIfCurrentStateIsIncompatible(order, State.FINISHED);
-        order.setState(State.FINISHED);
-
-        sendOrderEmail(order, "Order Finished");
-
-        return OrderMapper.toOrderResponse(
-                orderRepository.save(order),
-                orderRepository.getOrderTotal(order)
-        );
+    public OrderResponse finishOrder(UUID orderId) {
+        return changeOrderState(orderId, State.FINISHED);
     }
 
     @Override
     public OrderResponse markOrderInDelivery(UUID orderId) {
-        Order order = findOrderByIdOrThrowException(orderId);
-        throwExceptionIfCurrentStateIsIncompatible(order, State.IN_DELIVERY);
-        order.setState(State.IN_DELIVERY);
-
-        sendOrderEmail(order, "Order In Delivery");
-
-        return OrderMapper.toOrderResponse(
-                orderRepository.save(order),
-                orderRepository.getOrderTotal(order)
-        );
+        return changeOrderState(orderId, State.IN_DELIVERY);
     }
 
     @Override
     public OrderResponse deliverOrder(UUID orderId) {
-        Order order = findOrderByIdOrThrowException(orderId);
-        throwExceptionIfCurrentStateIsIncompatible(order, State.DELIVERED);
-        order.setState(State.DELIVERED);
+        return changeOrderState(orderId, State.DELIVERED);
+    }
 
-        sendOrderEmail(order, "Order Delivered");
+    @Override
+    public OrderResponse cancelOrder(UUID orderId) {
+        return changeOrderState(orderId, State.CANCELLED);
+    }
+
+    private OrderResponse changeOrderState(UUID orderId, State newState) {
+        Order order = findOrderByIdOrThrowException(orderId);
+        throwExceptionIfCurrentStateIsIncompatible(order, newState);
+        order.setState(newState);
+
+        sendOrderEmail(order, newState.subject);
 
         return OrderMapper.toOrderResponse(
                 orderRepository.save(order),

--- a/src/main/java/com/_up/megastore/services/interfaces/IOrderService.java
+++ b/src/main/java/com/_up/megastore/services/interfaces/IOrderService.java
@@ -17,4 +17,6 @@ public interface IOrderService {
     OrderResponse markOrderInDelivery(UUID orderId);
 
     OrderResponse deliverOrder(UUID orderId);
+
+    OrderResponse cancelOrder(UUID orderId);
 }

--- a/src/main/java/com/_up/megastore/services/interfaces/IOrderService.java
+++ b/src/main/java/com/_up/megastore/services/interfaces/IOrderService.java
@@ -1,5 +1,6 @@
 package com._up.megastore.services.interfaces;
 
+import com._up.megastore.controllers.requests.CancelOrderRequest;
 import com._up.megastore.controllers.requests.CreateOrderRequest;
 import com._up.megastore.controllers.responses.OrderResponse;
 import com._up.megastore.data.model.Order;
@@ -18,5 +19,5 @@ public interface IOrderService {
 
     OrderResponse deliverOrder(UUID orderId);
 
-    OrderResponse cancelOrder(UUID orderId);
+    OrderResponse cancelOrder(UUID orderId, CancelOrderRequest cancelOrderRequest);
 }

--- a/src/main/java/com/_up/megastore/services/mappers/OrderMapper.java
+++ b/src/main/java/com/_up/megastore/services/mappers/OrderMapper.java
@@ -27,6 +27,7 @@ public class OrderMapper {
                 order.getDate(),
                 order.getUser().getFullName(),
                 order.getState().name(),
+                order.getReasonToCancel(),
                 total,
                 buildOrderDetailsResponse(order.getOrderDetails())
         );

--- a/src/test/java/com/_up/megastore/integrations/implementations/OrderControllerTest.java
+++ b/src/test/java/com/_up/megastore/integrations/implementations/OrderControllerTest.java
@@ -1,5 +1,6 @@
 package com._up.megastore.integrations.implementations;
 
+import com._up.megastore.controllers.requests.CancelOrderRequest;
 import com._up.megastore.controllers.requests.CreateOrderRequest;
 import com._up.megastore.controllers.requests.OrderDetailRequest;
 import com._up.megastore.data.enums.State;
@@ -163,8 +164,12 @@ class OrderControllerTest extends BaseIntegrationTest {
     @Test
     @Sql("/scripts/orders/cancel_order.sql")
     void cancelOrderWithOrderInProgress() throws Exception {
+        final var cancelOrderRequest = new CancelOrderRequest("Bad products");
+
         String response = mockMvc.perform(
                         post("/api/v1/orders/95803676-823b-4454-9844-904d617f42e2/cancel")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(toJson(cancelOrderRequest))
                 ).andExpect(status().isOk())
                 .andReturn()
                 .getResponse()
@@ -176,8 +181,12 @@ class OrderControllerTest extends BaseIntegrationTest {
     @Test
     @Sql("/scripts/orders/cancel_order.sql")
     void cancelOrderWithOrderFinished() throws Exception {
+        final var cancelOrderRequest = new CancelOrderRequest("Bad products");
+
         String response = mockMvc.perform(
                         post("/api/v1/orders/e4990fed-48f6-40ab-b7a8-de242a57ab40/cancel")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(toJson(cancelOrderRequest))
                 ).andExpect(status().isOk())
                 .andReturn()
                 .getResponse()
@@ -189,8 +198,12 @@ class OrderControllerTest extends BaseIntegrationTest {
     @Test
     @Sql("/scripts/orders/cancel_order.sql")
     void cancelOrdeWithIncompatibleState() throws Exception {
+        final var cancelOrderRequest = new CancelOrderRequest("Bad products");
+
         String response = mockMvc.perform(
                         post("/api/v1/orders/1b8f7aef-7154-4f82-b48f-988556d74cad/cancel")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(toJson(cancelOrderRequest))
                 ).andExpect(status().isBadRequest())
                 .andReturn()
                 .getResponse()

--- a/src/test/java/com/_up/megastore/integrations/implementations/OrderControllerTest.java
+++ b/src/test/java/com/_up/megastore/integrations/implementations/OrderControllerTest.java
@@ -2,6 +2,7 @@ package com._up.megastore.integrations.implementations;
 
 import com._up.megastore.controllers.requests.CreateOrderRequest;
 import com._up.megastore.controllers.requests.OrderDetailRequest;
+import com._up.megastore.data.enums.State;
 import com._up.megastore.integrations.base.BaseIntegrationTest;
 import com._up.megastore.services.implementations.EmailService;
 import org.junit.jupiter.api.Test;
@@ -85,7 +86,7 @@ class OrderControllerTest extends BaseIntegrationTest {
                 .getResponse()
                 .getContentAsString();
 
-        assertContains(response, "state", "FINISHED");
+        assertContains(response, "state", State.FINISHED.name());
 
         verify(emailService, times(1)).sendEmail(anyString(), anyString(), anyString());
     }
@@ -100,7 +101,7 @@ class OrderControllerTest extends BaseIntegrationTest {
                 .getResponse()
                 .getContentAsString();
 
-        assertContains(response, "message", "Order is not in progress.");
+        assertContains(response, "message", State.FINISHED.exceptionMessage);
     }
 
     @Test
@@ -113,7 +114,7 @@ class OrderControllerTest extends BaseIntegrationTest {
                 .getResponse()
                 .getContentAsString();
 
-        assertContains(response, "state", "IN_DELIVERY");
+        assertContains(response, "state", State.IN_DELIVERY.name());
 
         verify(emailService, times(1)).sendEmail(anyString(), anyString(), anyString());
     }
@@ -128,7 +129,7 @@ class OrderControllerTest extends BaseIntegrationTest {
                 .getResponse()
                 .getContentAsString();
 
-        assertContains(response, "message", "Order is not finished.");
+        assertContains(response, "message", State.IN_DELIVERY.exceptionMessage);
     }
 
     @Test
@@ -141,7 +142,7 @@ class OrderControllerTest extends BaseIntegrationTest {
                 .getResponse()
                 .getContentAsString();
 
-        assertContains(response, "state", "DELIVERED");
+        assertContains(response, "state", State.DELIVERED.name());
 
         verify(emailService, times(1)).sendEmail(anyString(), anyString(), anyString());
     }
@@ -156,7 +157,46 @@ class OrderControllerTest extends BaseIntegrationTest {
                 .getResponse()
                 .getContentAsString();
 
-        assertContains(response, "message", "Order is not in delivery.");
+        assertContains(response, "message", State.DELIVERED.exceptionMessage);
+    }
+
+    @Test
+    @Sql("/scripts/orders/cancel_order.sql")
+    void cancelOrderWithOrderInProgress() throws Exception {
+        String response = mockMvc.perform(
+                        post("/api/v1/orders/95803676-823b-4454-9844-904d617f42e2/cancel")
+                ).andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        assertContains(response, "state", State.CANCELLED.name());
+    }
+
+    @Test
+    @Sql("/scripts/orders/cancel_order.sql")
+    void cancelOrderWithOrderFinished() throws Exception {
+        String response = mockMvc.perform(
+                        post("/api/v1/orders/e4990fed-48f6-40ab-b7a8-de242a57ab40/cancel")
+                ).andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        assertContains(response, "state", State.CANCELLED.name());
+    }
+
+    @Test
+    @Sql("/scripts/orders/cancel_order.sql")
+    void cancelOrdeWithIncompatibleState() throws Exception {
+        String response = mockMvc.perform(
+                        post("/api/v1/orders/1b8f7aef-7154-4f82-b48f-988556d74cad/cancel")
+                ).andExpect(status().isBadRequest())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        assertContains(response, "message", State.CANCELLED.exceptionMessage);
     }
 
 }

--- a/src/test/java/com/_up/megastore/services/implementations/OrderServiceTest.java
+++ b/src/test/java/com/_up/megastore/services/implementations/OrderServiceTest.java
@@ -27,7 +27,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-
 @ExtendWith(MockitoExtension.class)
 class OrderServiceTest {
 

--- a/src/test/java/com/_up/megastore/services/implementations/OrderServiceTest.java
+++ b/src/test/java/com/_up/megastore/services/implementations/OrderServiceTest.java
@@ -95,6 +95,26 @@ class OrderServiceTest {
                 assertEquals(orderResponse.state(), State.DELIVERED.name());
             });
         }
+
+        @Test
+        void cancelOrder_orderIsInProgress() {
+            order.setState(State.IN_PROGRESS);
+
+            assertDoesNotThrow(() -> {
+                final var orderResponse = orderService.cancelOrder(orderId);
+                assertEquals(orderResponse.state(), State.CANCELLED.name());
+            });
+        }
+
+        @Test
+        void cancelOrder_orderIsFinished() {
+            order.setState(State.FINISHED);
+
+            assertDoesNotThrow(() -> {
+                final var orderResponse = orderService.cancelOrder(orderId);
+                assertEquals(orderResponse.state(), State.CANCELLED.name());
+            });
+        }
     }
 
     @Nested
@@ -170,6 +190,24 @@ class OrderServiceTest {
         void deliverOrder_orderIsCancelled() {
             order.setState(State.CANCELLED);
             assertThrows(ResponseStatusException.class, () -> orderService.deliverOrder(orderId));
+        }
+
+        @Test
+        void cancelOrder_orderIsInDelivery() {
+            order.setState(State.IN_DELIVERY);
+            assertThrows(ResponseStatusException.class, () -> orderService.cancelOrder(orderId));
+        }
+
+        @Test
+        void cancelOrder_orderIsDelivered() {
+            order.setState(State.DELIVERED);
+            assertThrows(ResponseStatusException.class, () -> orderService.cancelOrder(orderId));
+        }
+
+        @Test
+        void cancelOrder_orderIsCancelled() {
+            order.setState(State.CANCELLED);
+            assertThrows(ResponseStatusException.class, () -> orderService.cancelOrder(orderId));
         }
     }
 }

--- a/src/test/java/com/_up/megastore/services/implementations/OrderServiceTest.java
+++ b/src/test/java/com/_up/megastore/services/implementations/OrderServiceTest.java
@@ -1,5 +1,6 @@
 package com._up.megastore.services.implementations;
 
+import com._up.megastore.controllers.requests.CancelOrderRequest;
 import com._up.megastore.data.enums.State;
 import com._up.megastore.data.model.Order;
 import com._up.megastore.data.model.User;
@@ -97,20 +98,22 @@ class OrderServiceTest {
 
         @Test
         void cancelOrder_orderIsInProgress() {
+            final var cancelOrderRequest = new CancelOrderRequest("Bad products");
             order.setState(State.IN_PROGRESS);
 
             assertDoesNotThrow(() -> {
-                final var orderResponse = orderService.cancelOrder(orderId);
+                final var orderResponse = orderService.cancelOrder(orderId, cancelOrderRequest);
                 assertEquals(orderResponse.state(), State.CANCELLED.name());
             });
         }
 
         @Test
         void cancelOrder_orderIsFinished() {
+            final var cancelOrderRequest = new CancelOrderRequest("Bad products");
             order.setState(State.FINISHED);
 
             assertDoesNotThrow(() -> {
-                final var orderResponse = orderService.cancelOrder(orderId);
+                final var orderResponse = orderService.cancelOrder(orderId, cancelOrderRequest);
                 assertEquals(orderResponse.state(), State.CANCELLED.name());
             });
         }
@@ -193,20 +196,26 @@ class OrderServiceTest {
 
         @Test
         void cancelOrder_orderIsInDelivery() {
+            final var cancelOrderRequest = new CancelOrderRequest("Bad products");
             order.setState(State.IN_DELIVERY);
-            assertThrows(ResponseStatusException.class, () -> orderService.cancelOrder(orderId));
+            assertThrows(ResponseStatusException.class, () ->
+                    orderService.cancelOrder(orderId, cancelOrderRequest));
         }
 
         @Test
         void cancelOrder_orderIsDelivered() {
+            final var cancelOrderRequest = new CancelOrderRequest("Bad products");
             order.setState(State.DELIVERED);
-            assertThrows(ResponseStatusException.class, () -> orderService.cancelOrder(orderId));
+            assertThrows(ResponseStatusException.class, () ->
+                    orderService.cancelOrder(orderId, cancelOrderRequest));
         }
 
         @Test
         void cancelOrder_orderIsCancelled() {
+            final var cancelOrderRequest = new CancelOrderRequest("Bad products");
             order.setState(State.CANCELLED);
-            assertThrows(ResponseStatusException.class, () -> orderService.cancelOrder(orderId));
+            assertThrows(ResponseStatusException.class, () ->
+                    orderService.cancelOrder(orderId, cancelOrderRequest));
         }
     }
 }

--- a/src/test/resources/scripts/orders/cancel_order.sql
+++ b/src/test/resources/scripts/orders/cancel_order.sql
@@ -1,0 +1,29 @@
+INSERT INTO sizes (size_id, name, description, deleted)
+VALUES ('03f667f7-4075-41f1-a35d-b4dc71f05b8a', 'Size name', 'Size description', FALSE);
+
+INSERT INTO categories (category_id, name, description, super_category_category_id, deleted)
+VALUES ('0bbad5ac-3986-4832-8a87-0141a83052ce', 'Category name', 'Category description', null, false);
+
+INSERT INTO product_images (url, name)
+VALUES ('url 1', 'image 1'),
+       ('url 2', 'image 2'),
+       ('url 3', 'image 3');
+
+INSERT INTO products (product_id, name, description, price, stock, color, size_size_id, category_category_id, deleted)
+VALUES ('183f205a-3430-4e11-8bca-57672a0ce3ff', 'Product name', 'Product description', 10000.0, 10, '#ffffff', '03f667f7-4075-41f1-a35d-b4dc71f05b8a', '0bbad5ac-3986-4832-8a87-0141a83052ce', false);
+
+INSERT INTO products (product_id, name, description, price, stock, color, size_size_id, category_category_id, deleted)
+VALUES ('22ede130-726f-49ac-9564-d783fc22a6fa', 'Variant name', 'Variant description', 10000.0, 10, '#ffffff', '03f667f7-4075-41f1-a35d-b4dc71f05b8a', '0bbad5ac-3986-4832-8a87-0141a83052ce', false);
+
+INSERT INTO products_images (products_product_id, images_url)
+VALUES ('183f205a-3430-4e11-8bca-57672a0ce3ff', 'url 1'),
+       ('183f205a-3430-4e11-8bca-57672a0ce3ff', 'url 2'),
+       ('22ede130-726f-49ac-9564-d783fc22a6fa', 'url 3');
+
+INSERT INTO users (user_id, username, password, full_name, email, activated, deleted)
+VALUES ('58fae25b-ea38-4e7b-ab2d-9f555a67836b', 'user test', 'password', 'Client Name', 'client@mail.com', true, false);
+
+INSERT INTO orders (order_id, deleted, state, user_user_id)
+VALUES ('95803676-823b-4454-9844-904d617f42e2', false, 'IN_PROGRESS', '58fae25b-ea38-4e7b-ab2d-9f555a67836b'),
+       ('e4990fed-48f6-40ab-b7a8-de242a57ab40', false, 'FINISHED', '58fae25b-ea38-4e7b-ab2d-9f555a67836b'),
+       ('1b8f7aef-7154-4f82-b48f-988556d74cad', false, 'IN_DELIVERY', '58fae25b-ea38-4e7b-ab2d-9f555a67836b');


### PR DESCRIPTION
Se implementó la funcionalidad para que tanto usuarios logueados como administradores puedan cancelar pedidos siempre y cuando **no estén en entrega**. Además de ello, como en los casos anteriores, se envía un mail al cliente asociado indicándole que su pedido se canceló con éxito.

## Tests

Al igual que en las otras MRs de cambios de estado, se agregaron los correspondientes tests unitarios y tests de integración. Con esto, tenemos **completados los casos de prueba de tests unitarios de cambios de estados**. Quedan como 55 casos de prueba más :smile:.

## Refactorización

Resulta que todos los cambios de estado ejecutan las mismas instrucciones. En vez de repetir código como un npc, agregué una función genérica para cambiar el estado de una orden según el método que se llame. Por ejemplo, para finalizar una orden:

```
OrderResponse finishOrder(UUID orderId) {
          return changeOrderState(orderId, State.FINISHED);
}

private OrderResponse changeOrderState(UUID orderId, State newState) {
         // ...
}
```

Esto mejora un poco la legibilidad en el orderService y nos permite evitar las duplicaciones. Es una pavada pero evidentemente no me di cuenta de esto en las MR anteriores.

## Seguridad

Resulta que la configuración de los endpoints en la clase SecurityConfig estaba **mal hecha**. Cada llamada a `AuthorizationManagerRequestMatcherRegistry.requestMatchers()` aplica la configuración a los endpoints e inhabilita las llamadas posteriores. Esto es, si tenemos lo siguiente:

```
httpSecurity.authorizeHttpRequests(authRequest -> 
          authRequest.requestMatchers("/demo/**").authenticated()
          authRequest.requestMatchers("/demo/hello-world").permitAll()
```

La segunda configuración (permitAll) no tendrá efecto alguno y deberemos estar autenticados para acceder al endpoint `demo/hello-world` por más que hayamos indicado lo contrario.

Este mismo caso ocurría en nuestra api, y ocasionaba problemas, por ejemplo, al momento de acceder a los pedidos como administradores logueados. 

En esta PR esto se solucionó, aplicando un enfoque un poco más robusto, separando cada endpoint no sólo por la URI sino también por el método HTTP. La configuración fue probada tanto con Postman como con el frontend y parece que funciona.