### PR TITLE
feat: expire token password

### DIFF
--- a/src/main/java/com/_up/megastore/controllers/requests/RecoverPasswordRequest.java
+++ b/src/main/java/com/_up/megastore/controllers/requests/RecoverPasswordRequest.java
@@ -1,17 +1,18 @@
 package com._up.megastore.controllers.requests;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
-import org.hibernate.validator.constraints.Length;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 import java.util.UUID;
 
 public record RecoverPasswordRequest(
-        @NotBlank(message = "Password must not be null")
-        @Length(min = 6, max = 20)
-        @Pattern(regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9])(?=.*[!¡¿?$%&#@_-])[A-Za-z0-9!¡¿?$%&#@_-]+$", message = "The password are not strong.")
+
+        @NotNull(message = "User password must not be null")
+        @Size(min = 6, max = 20, message = "User password must be between 6 and 20 characters")
         String password,
         String confirmPassword,
+
         @NotBlank(message = "RecoverPasswordToken must not be null")
         UUID recoverPasswordToken
 ) {}

--- a/src/main/java/com/_up/megastore/data/model/User.java
+++ b/src/main/java/com/_up/megastore/data/model/User.java
@@ -9,15 +9,15 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
 
 @Entity(name = "users")
 @NoArgsConstructor
@@ -58,9 +58,7 @@ public class User {
 
   @OneToMany(mappedBy = "user", cascade = {CascadeType.ALL})
   @Builder.Default
-  private List<Token> activationTokens = Collections.emptyList();
-
-  private UUID recoverPasswordToken = null;
+  private List<Token> tokens = Collections.emptyList();
 
   @Id
   private final UUID userId = UUID.randomUUID();

--- a/src/main/java/com/_up/megastore/data/repositories/IUserRepository.java
+++ b/src/main/java/com/_up/megastore/data/repositories/IUserRepository.java
@@ -15,6 +15,4 @@ public interface IUserRepository extends JpaRepository<User, UUID> {
   
   Optional<User> findByUsername(String username);
   
-  Optional<User> findByRecoverPasswordTokenIs(UUID recoverPasswordToken);
-
 }

--- a/src/main/java/com/_up/megastore/services/implementations/TokenService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/TokenService.java
@@ -28,13 +28,12 @@ public class TokenService implements ITokenService {
     }
 
     @Override
-    public User findUserByActivationToken(UUID activationToken){
-        Token token = findTokenByIdOrThrowException(activationToken);
-        return token.getUser();
+    public User findUserByToken(UUID tokenId) {
+        return findTokenByIdOrThrowException(tokenId).getUser();
     }
 
     @Override
-    public Token findTokenByIdOrThrowException(UUID token){
+    public Token findTokenByIdOrThrowException(UUID token) {
         return iTokenRepository.findById(token)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Token with UUID " + token + " does not exist."));
     }

--- a/src/main/java/com/_up/megastore/services/interfaces/ITokenService.java
+++ b/src/main/java/com/_up/megastore/services/interfaces/ITokenService.java
@@ -6,9 +6,13 @@ import com._up.megastore.data.model.User;
 import java.util.UUID;
 
 public interface ITokenService {
-    public Token saveToken(User user);
-    public User findUserByActivationToken(UUID activationToken);
-    public Token findTokenByIdOrThrowException(UUID token);
+
+    Token saveToken(User user);
+
+    User findUserByToken(UUID token);
+
+    Token findTokenByIdOrThrowException(UUID token);
 
     Token findActiveTokenByUser(User user);
+
 }

--- a/src/main/java/com/_up/megastore/utils/EmailBuilder.java
+++ b/src/main/java/com/_up/megastore/utils/EmailBuilder.java
@@ -34,8 +34,8 @@ public class EmailBuilder {
                 + "</table>";
     }
 
-    public String buildRecoverPasswordEmail(User user) {
-        String recoverPasswordURL = frontendURL + "/auth/recover-password?token=" + user.getRecoverPasswordToken();
+    public String buildRecoverPasswordEmail(String username, UUID recoverPasswordToken) {
+        String recoverPasswordURL = frontendURL + "/auth/recover-password?token=" + recoverPasswordToken;
 
         return "<!DOCTYPE html>\n"
                 + "<html>\n"
@@ -69,7 +69,7 @@ public class EmailBuilder {
                 + "            <h1>Password Recovery</h1>\n"
                 + "        </div>\n"
                 + "        <div class=\"content\">\n"
-                + "            <p>Hello " + user.getUsername() + ",</p>\n"
+                + "            <p>Hello " + username + ",</p>\n"
                 + "            <p>We received a request to reset your password. Click the button below to create a new password:</p>\n"
                 + "            <p style=\"display: flex; flex: content; justify-content: center;\"><a href=\" " + recoverPasswordURL + "\" class=\"button\">Reset Password</a></p>\n"
                 + "            <p>If you did not request this change, please ignore this email.</p>\n"

--- a/src/test/java/com/_up/megastore/unit/limit/ActivateUserTest.java
+++ b/src/test/java/com/_up/megastore/unit/limit/ActivateUserTest.java
@@ -60,7 +60,7 @@ public class ActivateUserTest {
         mockedDateTime = mockStatic(LocalDateTime.class);
         mockedDateTime.when(LocalDateTime::now).thenReturn(expectedDate);
 
-        when(tokenService.findUserByActivationToken(any(UUID.class))).thenReturn(user);
+        when(tokenService.findUserByToken(any(UUID.class))).thenReturn(user);
         when(tokenService.findTokenByIdOrThrowException(any(UUID.class))).thenReturn(token);
 
         when(user.isActivated()).thenReturn(false);

--- a/src/test/java/com/_up/megastore/unit/limit/UserTests.java
+++ b/src/test/java/com/_up/megastore/unit/limit/UserTests.java
@@ -1,5 +1,6 @@
 package com._up.megastore.unit.limit;
 
+import com._up.megastore.controllers.requests.RecoverPasswordRequest;
 import com._up.megastore.data.model.Token;
 import com._up.megastore.data.model.User;
 import com._up.megastore.data.repositories.IUserRepository;
@@ -15,6 +16,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
@@ -23,13 +25,14 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class ActivateUserTest {
+public class UserTests {
 
     @Mock
     private IUserRepository userRepository;
@@ -42,6 +45,9 @@ public class ActivateUserTest {
 
     @Mock
     private EmailService emailService;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
 
     @InjectMocks
     private UserService userService;
@@ -60,7 +66,6 @@ public class ActivateUserTest {
         mockedDateTime = mockStatic(LocalDateTime.class);
         mockedDateTime.when(LocalDateTime::now).thenReturn(expectedDate);
 
-        when(tokenService.findUserByToken(any(UUID.class))).thenReturn(user);
         when(tokenService.findTokenByIdOrThrowException(any(UUID.class))).thenReturn(token);
 
         when(user.isActivated()).thenReturn(false);
@@ -74,6 +79,7 @@ public class ActivateUserTest {
     @Test
     void activateUser_tokenIsNotExpired() {
         when(userRepository.save(any(User.class))).thenReturn(user);
+        when(tokenService.findUserByToken(any(UUID.class))).thenReturn(user);
         when(emailBuilder.buildWelcomeEmail(any(User.class))).thenReturn("Email content");
         doNothing().when(emailService).sendEmail(any(), any(), any());
 
@@ -85,5 +91,29 @@ public class ActivateUserTest {
     void activateUser_tokenIsExpired() {
         when(token.getTokenExpirationDate()).thenReturn(expiredDate);
         assertThrows(ResponseStatusException.class, () -> userService.activateUser(UUID.randomUUID(), UUID.randomUUID()));
+    }
+
+    @Test
+    void recoverPassword_tokenIsNotExpired() {
+        RecoverPasswordRequest recoverPasswordRequest = new RecoverPasswordRequest(
+            "password", "password", UUID.randomUUID()
+        );
+
+        when(userRepository.save(any(User.class))).thenReturn(user);
+        when(tokenService.findUserByToken(any(UUID.class))).thenReturn(user);
+        when(token.getTokenExpirationDate()).thenReturn(notExpiredDate);
+        when(passwordEncoder.encode(anyString())).thenReturn("Encoded password");
+
+        assertDoesNotThrow(() -> userService.recoverPassword(recoverPasswordRequest));
+    }
+
+    @Test
+    void recoverPassword_tokenIsExpired() {
+        RecoverPasswordRequest recoverPasswordRequest = new RecoverPasswordRequest(
+                "password", "password", UUID.randomUUID()
+        );
+
+        when(token.getTokenExpirationDate()).thenReturn(expiredDate);
+        assertThrows(ResponseStatusException.class, () -> userService.recoverPassword(recoverPasswordRequest));
     }
 }

--- a/src/test/java/com/_up/megastore/unit/states/UserStateTest.java
+++ b/src/test/java/com/_up/megastore/unit/states/UserStateTest.java
@@ -47,7 +47,7 @@ public class UserStateTest {
 
     @BeforeEach
     void setUp() {
-        when(tokenService.findUserByActivationToken(any(UUID.class))).thenReturn(user);
+        when(tokenService.findUserByToken(any(UUID.class))).thenReturn(user);
     }
 
     @Test

--- a/src/test/java/com/_up/megastore/unit/states/UserStateTest.java
+++ b/src/test/java/com/_up/megastore/unit/states/UserStateTest.java
@@ -48,17 +48,17 @@ public class UserStateTest {
     @BeforeEach
     void setUp() {
         when(tokenService.findUserByToken(any(UUID.class))).thenReturn(user);
+        when(tokenService.findTokenByIdOrThrowException(any(UUID.class))).thenReturn(token);
+        when(token.getTokenExpirationDate()).thenReturn(LocalDateTime.now().plusMinutes(10));
     }
 
     @Test
     void activateUser_userIsNotActivated() {
-        when(tokenService.findTokenByIdOrThrowException(any(UUID.class))).thenReturn(token);
         when(userRepository.save(any(User.class))).thenReturn(user);
         when(emailBuilder.buildWelcomeEmail(any(User.class))).thenReturn("Email content");
         doNothing().when(emailService).sendEmail(any(), any(), any());
 
         when(user.isActivated()).thenReturn(false);
-        when(token.getTokenExpirationDate()).thenReturn(LocalDateTime.now().plusMinutes(10));
 
         assertDoesNotThrow(() -> userService.activateUser(UUID.randomUUID(), UUID.randomUUID()));
     }


### PR DESCRIPTION
Se implementó la funcionalidad para que expiren los tokens de recuperación de contraseña de la misma manera que en #60. Además de ello, se modificó la request para que la validación de la contraseña restaurada sea igual a la validación de la contraseña en el signup.

## Tests

Se implementó el último caso de prueba faltante de los **tests unitarios de valor límite**. Con esto, tenemos 20/60 casos de prueba totales implementados. 