### PR TITLE
feat: get deleted products and categories

### DIFF
--- a/src/main/java/com/_up/megastore/controllers/implementations/CategoryController.java
+++ b/src/main/java/com/_up/megastore/controllers/implementations/CategoryController.java
@@ -5,9 +5,9 @@ import com._up.megastore.controllers.requests.CreateCategoryRequest;
 import com._up.megastore.controllers.requests.UpdateCategoryRequest;
 import com._up.megastore.controllers.responses.CategoryResponse;
 import com._up.megastore.services.interfaces.ICategoryService;
+import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.RestController;
-import java.util.UUID;
 
 @RestController
 public class CategoryController implements ICategoryController {
@@ -31,6 +31,11 @@ public class CategoryController implements ICategoryController {
     @Override
     public Page<CategoryResponse> readAllCategories(int page, int pageSize, String name){
         return categoryService.readAllCategories(page, pageSize, name);
+    }
+
+    @Override
+    public Page<CategoryResponse> readDeletedCategories(int page, int pageSize) {
+        return categoryService.readDeletedCategories(page, pageSize);
     }
 
     @Override

--- a/src/main/java/com/_up/megastore/controllers/implementations/ProductController.java
+++ b/src/main/java/com/_up/megastore/controllers/implementations/ProductController.java
@@ -5,12 +5,11 @@ import com._up.megastore.controllers.requests.CreateProductRequest;
 import com._up.megastore.controllers.requests.UpdateProductRequest;
 import com._up.megastore.controllers.responses.ProductResponse;
 import com._up.megastore.services.interfaces.IProductService;
+import java.util.List;
+import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
-import java.util.UUID;
 
 @RestController
 public class ProductController implements IProductController {
@@ -56,4 +55,8 @@ public class ProductController implements IProductController {
         return productService.getProducts(page, pageSize, name);
     }
 
+    @Override
+    public Page<ProductResponse> getDeletedProducts(int page, int pageSize) {
+        return productService.getDeletedProducts(page, pageSize);
+    }
 }

--- a/src/main/java/com/_up/megastore/controllers/interfaces/ICategoryController.java
+++ b/src/main/java/com/_up/megastore/controllers/interfaces/ICategoryController.java
@@ -5,10 +5,17 @@ import com._up.megastore.controllers.requests.UpdateCategoryRequest;
 import com._up.megastore.controllers.responses.CategoryResponse;
 import jakarta.validation.Valid;
 import java.util.UUID;
-
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
 
 
@@ -26,6 +33,13 @@ public interface ICategoryController {
     Page<CategoryResponse> readAllCategories(@RequestParam(defaultValue = "0") int page,
                                              @RequestParam(defaultValue = "15") int pageSize,
                                              @RequestParam(defaultValue = "") String name);
+
+    @GetMapping(value = "/deleted")
+    @ResponseStatus(HttpStatus.OK)
+    Page<CategoryResponse> readDeletedCategories(
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "15") int pageSize
+    );
 
     @DeleteMapping(value = "/{categoryId}") @ResponseStatus(HttpStatus.NO_CONTENT)
     void deleteCategory(@PathVariable UUID categoryId);

--- a/src/main/java/com/_up/megastore/controllers/interfaces/IProductController.java
+++ b/src/main/java/com/_up/megastore/controllers/interfaces/IProductController.java
@@ -4,6 +4,8 @@ import com._up.megastore.controllers.requests.CreateProductRequest;
 import com._up.megastore.controllers.requests.UpdateProductRequest;
 import com._up.megastore.controllers.responses.ProductResponse;
 import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -18,9 +20,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
-import java.util.UUID;
 
 @RequestMapping("/api/v1/products")
 public interface IProductController {
@@ -63,4 +62,9 @@ public interface IProductController {
     Page<ProductResponse> getProducts(@RequestParam(defaultValue = "0") int page,
                                       @RequestParam(defaultValue = "15") int pageSize,
                                       @RequestParam(defaultValue = "") String name);
+
+    @GetMapping("/deleted")
+    @ResponseStatus(HttpStatus.OK)
+    Page<ProductResponse> getDeletedProducts(@RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "15") int pageSize);
 }

--- a/src/main/java/com/_up/megastore/controllers/responses/ProductResponse.java
+++ b/src/main/java/com/_up/megastore/controllers/responses/ProductResponse.java
@@ -12,5 +12,7 @@ public record ProductResponse(
         int stock,
         String color,
         String sizeName,
-        UUID variantOfId
+        UUID variantOfId,
+        String variantOfName,
+        Boolean hasVariants
 ) {}

--- a/src/main/java/com/_up/megastore/data/repositories/ICategoryRepository.java
+++ b/src/main/java/com/_up/megastore/data/repositories/ICategoryRepository.java
@@ -1,12 +1,14 @@
 package com._up.megastore.data.repositories;
 
 import com._up.megastore.data.model.Category;
+import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import java.util.UUID;
 
 public interface ICategoryRepository extends JpaRepository<Category, UUID> {
     Page<Category> findCategoryByDeletedIsFalseAndNameContainingIgnoreCase(String name, Pageable pageable);
     boolean existsByNameAndDeletedIsFalse(String name);
+
+    Page<Category> findCategoriesByDeletedIsTrue(Pageable pageable);
 }

--- a/src/main/java/com/_up/megastore/data/repositories/IProductRepository.java
+++ b/src/main/java/com/_up/megastore/data/repositories/IProductRepository.java
@@ -1,17 +1,17 @@
 package com._up.megastore.data.repositories;
 
 import com._up.megastore.data.model.Product;
+import java.util.List;
+import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-import java.util.UUID;
-
 public interface IProductRepository extends JpaRepository<Product, UUID> {
-    boolean existsByProductIdAndDeletedTrue(UUID productId);
     Page<Product> findProductsByDeletedIsFalseAndVariantOfIsNullAndNameContainingIgnoreCase(String name, Pageable pageable);
-    boolean existsByNameIgnoreCaseAndDeletedIsFalse(String name);
+    Page<Product> findProductsByDeletedIsFalseAndNameContainingIgnoreCase(String name,
+        Pageable pageable);
     boolean existsByVariantOfAndDeletedFalse(Product variantOf);
     List<Product> findProductByVariantOfAndDeletedFalse(Product variantOf);
+    Page<Product> findProductsByDeletedIsTrue(Pageable pageable);
 }

--- a/src/main/java/com/_up/megastore/services/implementations/CategoryService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/CategoryService.java
@@ -9,14 +9,13 @@ import com._up.megastore.data.repositories.ICategoryRepository;
 import com._up.megastore.services.interfaces.ICategoryService;
 import com._up.megastore.services.mappers.CategoryMapper;
 import jakarta.transaction.Transactional;
+import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
-
-import java.util.UUID;
 
 @Service
 public class CategoryService implements ICategoryService {
@@ -56,6 +55,13 @@ public class CategoryService implements ICategoryService {
     public Page<CategoryResponse> readAllCategories(int page, int pageSize, String name){
         Pageable pageable = PageRequest.of(page, pageSize);
         return categoryRepository.findCategoryByDeletedIsFalseAndNameContainingIgnoreCase(name,pageable).map(CategoryMapper::toCategoryResponse);
+    }
+
+    @Override
+    public Page<CategoryResponse> readDeletedCategories(int page, int pageSize) {
+        Pageable pageable = PageRequest.of(page, pageSize);
+        return categoryRepository.findCategoriesByDeletedIsTrue(pageable)
+            .map(CategoryMapper::toCategoryResponse);
     }
 
     @Override

--- a/src/main/java/com/_up/megastore/services/implementations/ProductService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/ProductService.java
@@ -1,5 +1,7 @@
 package com._up.megastore.services.implementations;
 
+import static com._up.megastore.data.Constants.PRODUCT_WITH_ID;
+
 import com._up.megastore.controllers.requests.CreateProductRequest;
 import com._up.megastore.controllers.requests.UpdateProductRequest;
 import com._up.megastore.controllers.responses.ProductResponse;
@@ -14,6 +16,9 @@ import com._up.megastore.services.interfaces.IProductService;
 import com._up.megastore.services.interfaces.ISizeService;
 import com._up.megastore.services.mappers.ProductMapper;
 import jakarta.transaction.Transactional;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -21,12 +26,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
-
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.UUID;
-
-import static com._up.megastore.data.Constants.PRODUCT_WITH_ID;
 
 @Service
 public class ProductService implements IProductService {
@@ -130,8 +129,15 @@ public class ProductService implements IProductService {
     @Override
     public Page<ProductResponse> getProducts(int page, int pageSize, String name) {
         Pageable pageable = PageRequest.of(page, pageSize);
-        return productRepository.findProductsByDeletedIsFalseAndVariantOfIsNullAndNameContainingIgnoreCase(name, pageable)
+        return productRepository.findProductsByDeletedIsFalseAndNameContainingIgnoreCase(name, pageable)
                 .map(ProductMapper::toProductResponse);
+    }
+
+    @Override
+    public Page<ProductResponse> getDeletedProducts(int page, int pageSize) {
+        Pageable pageable = PageRequest.of(page, pageSize);
+        return productRepository.findProductsByDeletedIsTrue(pageable)
+            .map(ProductMapper::toProductResponse);
     }
 
     @Override

--- a/src/main/java/com/_up/megastore/services/interfaces/ICategoryService.java
+++ b/src/main/java/com/_up/megastore/services/interfaces/ICategoryService.java
@@ -4,9 +4,8 @@ import com._up.megastore.controllers.requests.CreateCategoryRequest;
 import com._up.megastore.controllers.requests.UpdateCategoryRequest;
 import com._up.megastore.controllers.responses.CategoryResponse;
 import com._up.megastore.data.model.Category;
-import org.springframework.data.domain.Page;
-
 import java.util.UUID;
+import org.springframework.data.domain.Page;
 
 public interface ICategoryService {
 
@@ -18,6 +17,8 @@ public interface ICategoryService {
     CategoryResponse readCategory(UUID categoryRequest);
 
     Page<CategoryResponse> readAllCategories(int page, int pageSize, String name);
+
+    Page<CategoryResponse> readDeletedCategories(int page, int pageSize);
 
     void deleteCategory(UUID categoryId);
 

--- a/src/main/java/com/_up/megastore/services/interfaces/IProductService.java
+++ b/src/main/java/com/_up/megastore/services/interfaces/IProductService.java
@@ -4,11 +4,10 @@ import com._up.megastore.controllers.requests.CreateProductRequest;
 import com._up.megastore.controllers.requests.UpdateProductRequest;
 import com._up.megastore.controllers.responses.ProductResponse;
 import com._up.megastore.data.model.Product;
-import org.springframework.data.domain.Page;
-import org.springframework.web.multipart.MultipartFile;
-
 import java.util.List;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface IProductService {
 
@@ -27,6 +26,8 @@ public interface IProductService {
     List<ProductResponse> getProductVariants(UUID productId);
 
     Page<ProductResponse> getProducts(int page, int pageSize, String name);
+
+    Page<ProductResponse> getDeletedProducts(int page, int pageSize);
 
     void discountProductStock(Integer quantity, Product product);
 

--- a/src/main/java/com/_up/megastore/services/mappers/ProductMapper.java
+++ b/src/main/java/com/_up/megastore/services/mappers/ProductMapper.java
@@ -15,6 +15,9 @@ public class ProductMapper {
 
     public static ProductResponse toProductResponse(Product product) {
         UUID variantOfId = getVariantOfId(product.getVariantOf());
+        String variantOfName = getVariantOfName(product.getVariantOf());
+        Boolean hasVariants = product.getVariants().stream()
+            .anyMatch(variant -> !variant.isDeleted());
         List<String> imagesURLS = getImagesURLs(product);
 
         return new ProductResponse(
@@ -26,7 +29,9 @@ public class ProductMapper {
                 product.getStock(),
                 product.getColor(),
                 product.getSize().getName(),
-            variantOfId
+                variantOfId,
+                variantOfName,
+                hasVariants
         );
     }
 
@@ -42,6 +47,10 @@ public class ProductMapper {
                 .images(images)
                 .variantOf(variantOf)
                 .build();
+    }
+
+    private static String getVariantOfName(Product variant) {
+        return variant != null ? variant.getName() : null;
     }
 
     private static UUID getVariantOfId(Product variant) {


### PR DESCRIPTION
Ahora existe un endpoint para obtener los productos y las categorías eliminadas. 

Con respecto a los productos, cambié un par de cosas:
- La respuesta del ProductResponse, agregué atributos como _hasVariants_ y _variantOfName_, ya que son importantes en el frontend para mostrar información y para ofrecer una mejor experiencia de usuario a la hora de querer eliminar un producto: al tener el _hasVariants_ podemos habilitar/deshabilitar el botón de eliminar producto como más nos convenga.
- Opté por mostrar todos los productos, es decir, el super producto y sus variantes. Ya que como administrador en el panel necesito ver todos y no solo los super productos, creo que esto es lo más fácil y rápido que podemos hacer.

![image](https://github.com/user-attachments/assets/7fd397f0-fe50-4809-8010-a4d5dff4326a)
Ahí podemos ver cómo el botón está deshabilitado ya que el producto tiene variantes.