### PR TITLE
fix: reports and security

### DIFF
--- a/src/main/java/com/_up/megastore/security/filter/JWTAuthenticationFilter.java
+++ b/src/main/java/com/_up/megastore/security/filter/JWTAuthenticationFilter.java
@@ -26,6 +26,7 @@ import static com._up.megastore.security.utils.Constants.BEARER;
 import static com._up.megastore.security.utils.Constants.JWT_EXCEPTION_DEFAULT_MESSAGE;
 import static com._up.megastore.security.utils.Endpoints.ANY_USER_ENDPOINTS;
 import static com._up.megastore.security.utils.Endpoints.AUTH_ENDPOINTS;
+import static com._up.megastore.security.utils.Endpoints.DELETED_ENTITIES_ENDPOINTS;
 import static com._up.megastore.security.utils.Endpoints.ERROR_ENDPOINTS;
 import static com._up.megastore.security.utils.Endpoints.PUBLIC_INFORMATION_ENDPOINTS;
 
@@ -83,11 +84,14 @@ public class JWTAuthenticationFilter extends OncePerRequestFilter {
         boolean isAnyUserEndpoint = pathMatcher.match(ANY_USER_ENDPOINTS, request.getRequestURI())
                 && request.getMethod().equals(HttpMethod.POST.name());
 
+        boolean isDeletedEndpoint = Stream.of(DELETED_ENTITIES_ENDPOINTS)
+                .anyMatch(url -> pathMatcher.match(url, request.getRequestURI()));
+
         boolean isPublicInformationEndpoint = Stream.of(PUBLIC_INFORMATION_ENDPOINTS)
                 .anyMatch(url -> pathMatcher.match(url, request.getRequestURI()))
                 && request.getMethod().equals(HttpMethod.GET.name());
 
-        return isOptionsMethod || isAuthEndpoint || isErrorEndpoint || isAnyUserEndpoint || isPublicInformationEndpoint;
+        return (isOptionsMethod || isAuthEndpoint || isErrorEndpoint || isAnyUserEndpoint || isPublicInformationEndpoint) && !isDeletedEndpoint;
     }
 
     private String extractTokenFromRequest(HttpServletRequest request) {

--- a/src/main/java/com/_up/megastore/security/utils/Endpoints.java
+++ b/src/main/java/com/_up/megastore/security/utils/Endpoints.java
@@ -15,9 +15,9 @@ public class Endpoints {
     public static final String REPORTS_ENDPOINTS = "/api/v1/reports/*";
 
     public static final String[] DELETED_ENTITIES_ENDPOINTS = {
-            "/api/v1/products/*/deleted",
-            "/api/v1/sizes/*/deleted",
-            "/api/v1/categories/*/deleted",
+            "/api/v1/products/deleted",
+            "/api/v1/sizes/deleted",
+            "/api/v1/categories/deleted",
     };
 
     public static final String[] PUBLIC_INFORMATION_ENDPOINTS = {

--- a/src/main/resources/package.sql
+++ b/src/main/resources/package.sql
@@ -11,12 +11,12 @@ CREATE PROCEDURE IF NOT EXISTS SP_FIND_ORDERS_BY_STATE(
     OUT total_out INTEGER
 )
 BEGIN
-    SELECT SUM(state = 'IN_PROGRESS'),
-           SUM(state = 'FINISHED'),
-           SUM(state = 'IN_DELIVERY'),
-           SUM(state = 'DELIVERED'),
-           SUM(state = 'CANCELLED'),
-           COUNT(*)
+    SELECT IFNULL(SUM(state = 'IN_PROGRESS'), 0),
+           IFNULL(SUM(state = 'FINISHED'), 0),
+           IFNULL(SUM(state = 'IN_DELIVERY'), 0),
+           IFNULL(SUM(state = 'DELIVERED'), 0),
+           IFNULL(SUM(state = 'CANCELLED'), 0),
+           IFNULL(COUNT(*), 0)
     INTO
         in_progress_out,
         finished_out,


### PR DESCRIPTION
Se realizaron dos fixes de implementaciones previas:

1. En el procedimiento almacenado de get orders by state ocurría un null pointer cuando no había pedidos entre las fechas ingresadas. Esto ocurría porque, en MySql, cuando se realiza un SUM de una entidad que no se encuentra, en vez de devolver 0 se devuelve NULL. Esto se solucionó con la sentencia IFNULL que previene estos casos.
2. En la obtención de las entidades eliminadas, los usuarios normales podían acceder al endpoint. Esto se solucionó modificando los endpoints dentro de la clase Endpoints (estaban mal escritos) y añadiendo una condición extra en el método shouldNotFilter del JWT para indicar que los endpoints de entidades eliminadas SÍ se filtren.