### PR TITLE
feat: get orders by user

### DIFF
--- a/src/main/java/com/_up/megastore/config/SecurityConfig.java
+++ b/src/main/java/com/_up/megastore/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -30,6 +31,7 @@ import static com._up.megastore.security.utils.Endpoints.USER_ORDER_MODIFICATION
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 public class SecurityConfig {
 
   private final AuthenticationProvider authenticationProvider;
@@ -54,6 +56,7 @@ public class SecurityConfig {
             .requestMatchers(HttpMethod.OPTIONS).permitAll()
             .requestMatchers(AUTH_ENDPOINTS, ERROR_ENDPOINTS).permitAll()
             .requestMatchers(HttpMethod.POST, ANY_USER_ENDPOINTS).permitAll()
+            .requestMatchers(HttpMethod.GET, ANY_USER_ENDPOINTS).permitAll()
             .requestMatchers(HttpMethod.GET, DELETED_ENTITIES_ENDPOINTS).hasRole(Role.ADMIN.name())
             .requestMatchers(HttpMethod.GET, REPORTS_ENDPOINTS).hasRole(Role.ADMIN.name())
             .requestMatchers(HttpMethod.GET, PUBLIC_INFORMATION_ENDPOINTS).permitAll()

--- a/src/main/java/com/_up/megastore/controllers/implementations/UserController.java
+++ b/src/main/java/com/_up/megastore/controllers/implementations/UserController.java
@@ -5,6 +5,7 @@ import com._up.megastore.controllers.requests.ActivateUserRequest;
 import com._up.megastore.controllers.requests.RecoverPasswordRequest;
 import com._up.megastore.controllers.requests.SendEmailRequest;
 import com._up.megastore.controllers.requests.SendNewActivationTokenRequest;
+import com._up.megastore.controllers.responses.OrderResponse;
 import com._up.megastore.services.implementations.UserService;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -42,5 +43,10 @@ public class UserController implements IUserController {
   @Override
   public void sendNewActivationToken(SendNewActivationTokenRequest sendNewActivationTokenRequest) {
     userService.sendNewActivationToken(sendNewActivationTokenRequest);
+  }
+
+  @Override
+  public OrderResponse[] getOrders(String username) {
+    return userService.getOrders(username);
   }
 }

--- a/src/main/java/com/_up/megastore/controllers/interfaces/IUserController.java
+++ b/src/main/java/com/_up/megastore/controllers/interfaces/IUserController.java
@@ -4,8 +4,10 @@ import com._up.megastore.controllers.requests.ActivateUserRequest;
 import com._up.megastore.controllers.requests.RecoverPasswordRequest;
 import com._up.megastore.controllers.requests.SendEmailRequest;
 import com._up.megastore.controllers.requests.SendNewActivationTokenRequest;
+import com._up.megastore.controllers.responses.OrderResponse;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -32,4 +34,8 @@ public interface IUserController {
 
   @PostMapping("/send-new-activation-token")
   void sendNewActivationToken(@RequestBody SendNewActivationTokenRequest sendNewActivationTokenRequest);
+
+  @GetMapping("/{username}/orders")
+  @ResponseStatus(HttpStatus.OK)
+  OrderResponse[] getOrders(@PathVariable String username);
 }

--- a/src/main/java/com/_up/megastore/controllers/responses/AuthResponse.java
+++ b/src/main/java/com/_up/megastore/controllers/responses/AuthResponse.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 
 public record AuthResponse(
         UUID userId,
+        String username,
         String accessToken,
         Role role
 ) {}

--- a/src/main/java/com/_up/megastore/exception/ExceptionControllerAdvice.java
+++ b/src/main/java/com/_up/megastore/exception/ExceptionControllerAdvice.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -14,6 +15,7 @@ import java.time.LocalDateTime;
 import java.util.NoSuchElementException;
 
 import static com._up.megastore.exception.ExceptionMessages.INVALID_FORMAT_EXCEPTION_MESSAGE;
+import static com._up.megastore.exception.ExceptionMessages.ACCESS_DENIED_EXCEPTION_MESSAGE;
 
 @RestControllerAdvice
 public class ExceptionControllerAdvice {
@@ -99,6 +101,17 @@ public class ExceptionControllerAdvice {
       };
     }
 
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    @ExceptionHandler(AccessDeniedException.class)
+    public ExceptionPayload handleAccessDeniedException(AccessDeniedException ex) {
+      return new ExceptionPayload(
+              ACCESS_DENIED_EXCEPTION_MESSAGE,
+              HttpStatus.FORBIDDEN.value(),
+              LocalDateTime.now(),
+              ex.getStackTrace()
+      );
+    }
+
     private ExceptionPayload handleInvalidFormatException(InvalidFormatException ex) {
       return new ExceptionPayload(
               INVALID_FORMAT_EXCEPTION_MESSAGE,
@@ -107,5 +120,4 @@ public class ExceptionControllerAdvice {
               ex.getStackTrace()
       );
     }
-
 }

--- a/src/main/java/com/_up/megastore/exception/ExceptionMessages.java
+++ b/src/main/java/com/_up/megastore/exception/ExceptionMessages.java
@@ -3,4 +3,5 @@ package com._up.megastore.exception;
 public class ExceptionMessages {
     private ExceptionMessages() {}
     public static final String INVALID_FORMAT_EXCEPTION_MESSAGE = "Can't parse float values to integers";
+    public static final String ACCESS_DENIED_EXCEPTION_MESSAGE = "You're not allowed to access this resource";
 }

--- a/src/main/java/com/_up/megastore/services/implementations/AuthService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/AuthService.java
@@ -39,7 +39,7 @@ public class AuthService implements IAuthService {
     ifUserIsNotActivatedThrowException(user);
     String accessToken = jwtService.generateAccessToken(user);
 
-    return new AuthResponse(user.getUserId(), accessToken, user.getUsername() ,user.getRole());
+    return new AuthResponse(user.getUserId(), user.getUsername(), accessToken, user.getRole());
   }
 
   private void ifUserIsNotActivatedThrowException(User user) {

--- a/src/main/java/com/_up/megastore/services/implementations/AuthService.java
+++ b/src/main/java/com/_up/megastore/services/implementations/AuthService.java
@@ -39,7 +39,7 @@ public class AuthService implements IAuthService {
     ifUserIsNotActivatedThrowException(user);
     String accessToken = jwtService.generateAccessToken(user);
 
-    return new AuthResponse(user.getUserId(), accessToken, user.getRole());
+    return new AuthResponse(user.getUserId(), accessToken, user.getUsername() ,user.getRole());
   }
 
   private void ifUserIsNotActivatedThrowException(User user) {

--- a/src/main/java/com/_up/megastore/services/interfaces/IUserService.java
+++ b/src/main/java/com/_up/megastore/services/interfaces/IUserService.java
@@ -26,6 +26,6 @@ public interface IUserService {
 
   void sendNewActivationToken(SendNewActivationTokenRequest sendNewActivationTokenRequest);
 
-  @PreAuthorize("#username == authentication.getName()")
+  @PreAuthorize("#username == authentication.getName() || hasRole('ROLE_ADMIN')")
   OrderResponse[] getOrders(String username);
 }

--- a/src/main/java/com/_up/megastore/services/interfaces/IUserService.java
+++ b/src/main/java/com/_up/megastore/services/interfaces/IUserService.java
@@ -4,8 +4,10 @@ import com._up.megastore.controllers.requests.RecoverPasswordRequest;
 import com._up.megastore.controllers.requests.SendEmailRequest;
 import com._up.megastore.controllers.requests.SendNewActivationTokenRequest;
 import com._up.megastore.controllers.requests.SignUpRequest;
+import com._up.megastore.controllers.responses.OrderResponse;
 import com._up.megastore.data.model.User;
 import java.util.UUID;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 public interface IUserService {
 
@@ -23,4 +25,7 @@ public interface IUserService {
   void resendActivationEmail(SendEmailRequest sendEmailRequest);
 
   void sendNewActivationToken(SendNewActivationTokenRequest sendNewActivationTokenRequest);
+
+  @PreAuthorize("#username == authentication.getName()")
+  OrderResponse[] getOrders(String username);
 }


### PR DESCRIPTION
Ahora es posible visualizar las órdenes de un usuario a través de su username.

Inicialmente se había planteado hacerlo mediante el ID del usuario, pero, de manera más práctica, y aprovechando los métodos de seguridad como @PreAuthorize, se opta por utilizar el username, ya que el holder no expone el ID del usuario autenticado.

En cuanto a los permisos de lectura, se establecen de la siguiente manera:
- El usuario que realiza la solicitud debe ser el creador de las órdenes o tener rol de administrador.